### PR TITLE
Fix old exception syntax that breaks Python 3 compatibility

### DIFF
--- a/Quandl/Quandl.py
+++ b/Quandl/Quandl.py
@@ -309,7 +309,7 @@ def _getauthtoken(token):
         try:
             pickle.dump(token, open('authtoken.p', 'wb'))
             print("Token {} activated and saved for later use.".format(token))
-        except Exception,e:
+        except Exception as e:
             print("Error writing token to cache: {}".format(str(e)))
 
     elif not savedtoken and not token:


### PR DESCRIPTION
This patch restores Python 3 compatibility.
