### PR TITLE
Echoing a user's token to STDOUT is bad security

### DIFF
--- a/Quandl/Quandl.py
+++ b/Quandl/Quandl.py
@@ -329,9 +329,9 @@ def _getauthtoken(token,text):
                 pass
                 
             else:
-                print("Token {} activated and saved for later use.".format(token))
+                print("Token activated and saved for later use.".format(token))
         except Exception as e:
-            print("Error writing token to cache: {}".format(str(e)))
+            print("Error writing token to cache".format(str(e)))
 
     elif not savedtoken and not token:
             if text == "no" or text == False:
@@ -344,7 +344,7 @@ def _getauthtoken(token,text):
         if text == "no":
              pass
         else:
-            print("Using cached token {} for authentication.".format(token))
+            print("Using cached token from authtoken.p for authentication.".format(token))
     return token
 
 


### PR DESCRIPTION
I noticed that the _getauthtoken method automatically echoes a user's token to STDOUT when saving to Pickle and when loading from Pickle. This patch removes tokens from the error messages and adds a clarifying note to the Pickle save message.

If this is left unpatched, tokens will end up on system logs which is bad practice.