### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy==1.7.1
-pandas==0.11
+numpy>=1.7.1
+pandas>=0.11


### PR DESCRIPTION
Currently requirements.txt only allows for numpy 1.7.1 and pandas 0.11. Users with newer versions are therefore forced to install older versions of these modules. Requirements.txt should be changed from:

    numpy==1.7.1
    pandas==0.11

to:

    numpy>=1.7.1
    pandas>=0.11

This saves users from having to recompile an old version of numpy, if they already have a newer version installed.