### PR TITLE
Ap 1624/backwards compatibility

### DIFF
--- a/quandl/__init__.py
+++ b/quandl/__init__.py
@@ -9,6 +9,8 @@ from .model.dataset import Dataset
 from .model.datatable import Datatable
 from .model.data import Data
 from .model.merged_dataset import MergedDataset
+from .get import get
+from .bulkdownload import bulkdownload
 import warnings
 import copy, os
 

--- a/quandl/bulkdownload.py
+++ b/quandl/bulkdownload.py
@@ -1,0 +1,26 @@
+from quandl.errors.quandl_error import InvalidRequestError
+from .utils.api_key_util import ApiKeyUtil
+from .model.database import Database
+
+
+def bulkdownload(database, **kwargs):
+    """Downloads an entire database.
+    :param str database: The database code to download
+    :param str filename: The filename for the download. \
+    If not specified, will download to the current working directory
+    :param str api_key: Most databases require api_key for bulk download
+    :param str download_type: 'partial' or 'complete'. \
+    See: https://www.quandl.com/docs/api#database-metadata
+    """
+
+    # discourage users from using authtoken
+    if 'authtoken' in kwargs:
+        error_msg = "Parameter authtoken is no longer supported. \
+        For more information please see \
+        https://github.com/quandl/quandl-python/blob/master/README.md"
+        raise InvalidRequestError(error_msg)
+
+    ApiKeyUtil.init_api_key_from_args(kwargs)
+
+    filename = kwargs.pop('filename', '.')
+    return Database(database).bulk_download_to_file(filename, params=kwargs)

--- a/quandl/get.py
+++ b/quandl/get.py
@@ -1,0 +1,93 @@
+from quandl.errors.quandl_error import InvalidRequestError
+from .model.dataset import Dataset
+from .model.merged_dataset import MergedDataset
+from .utils.api_key_util import ApiKeyUtil
+from six import string_types
+import warnings
+
+OLD_TO_NEW_PARAMS = {'authtoken': 'api_key', 'trim_start': 'start_date',
+                     'trim_end': 'end_date', 'transformation': 'transform',
+                     'sort_order': 'order'}
+
+
+def get(dataset, **kwargs):
+    """Return dataframe of requested dataset from Quandl.
+    :param dataset: str or list, depending on single dataset usage or multiset usage
+            Dataset codes are available on the Quandl website
+    :param str api_key: Downloads are limited to 50 unless api_key is specified
+    :param str start_date, end_date: Optional datefilers, otherwise entire
+           dataset is returned
+    :param str collapse: Options are daily, weekly, monthly, quarterly, annual
+    :param str transform: options are diff, rdiff, cumul, and normalize
+    :param int rows: Number of rows which will be returned
+    :param str order: options are asc, desc. Default: `asc`
+    :param str returns: specify what format you wish your dataset returned as,
+        either `numpy` for a numpy ndarray or `pandas`. Default: `pandas`
+    :returns: :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+    Note that Pandas expects timeseries data to be sorted ascending for most
+    timeseries functionality to work.
+    Any other `kwargs` passed to `get` are sent as field/value params to Quandl
+    with no interference.
+    """
+
+    _convert_params_to_v3(kwargs)
+
+    data_format = kwargs.pop('returns', 'pandas')
+
+    ApiKeyUtil.init_api_key_from_args(kwargs)
+
+    # Check whether dataset is given as a string
+    # (for a single dataset) or an array (for a multiset call)
+
+    # Unicode String
+    if isinstance(dataset, string_types):
+        dataset_args = _parse_dataset_code(dataset)
+        if dataset_args['column_index'] is not None:
+            kwargs.update({'column_index': dataset_args['column_index']})
+        data = Dataset(dataset_args['code']).data(params=kwargs)
+    # Array
+    elif isinstance(dataset, list):
+        args = _build_merged_dataset_args(dataset)
+        # handle_not_found_error if set to True will add an empty DataFrame
+        # for a non-existent dataset instead of raising an error
+        data = MergedDataset(args).data(params=kwargs, handle_not_found_error=True)
+    # If wrong format
+    else:
+        error = "Your dataset must either be specified as a string \
+(containing a Quandl code) or an array (of Quandl codes)"
+        raise InvalidRequestError(error)
+
+    if data_format == 'numpy':
+        return data.to_numpy()
+    return data.to_pandas()
+
+
+def _parse_dataset_code(dataset):
+    if '.' not in dataset:
+        return {'code': dataset, 'column_index': None}
+    dataset_temp = dataset.split('.')
+    if not dataset_temp[1].isdigit():
+        raise ValueError("The column index needs to be an integer in %s" % dataset)
+    return {'code': dataset_temp[0], 'column_index': int(dataset_temp[1])}
+
+
+def _build_merged_dataset_args(datasets):
+    merged_dataset_args = []
+    for dataset in datasets:
+        dataset_code_column = _parse_dataset_code(dataset)
+        arg = dataset_code_column['code']
+        column_index = dataset_code_column['column_index']
+        if column_index is not None:
+            arg = (dataset_code_column['code'], {'column_index': [column_index]})
+        merged_dataset_args.append(arg)
+    return merged_dataset_args
+
+
+def _convert_params_to_v3(params):
+    for k, v in OLD_TO_NEW_PARAMS.items():
+        if k in params:
+            msg = "%s will no longer supported. Please use %s instead." % (k, v)
+            warnings.warn(msg, DeprecationWarning)
+            # update to the new query param if not specified already
+            if v not in params:
+                params[v] = params.pop(k)

--- a/quandl/model/database.py
+++ b/quandl/model/database.py
@@ -14,6 +14,7 @@ from quandl.errors.quandl_error import QuandlError
 from quandl.operations.get import GetOperation
 from quandl.operations.list import ListOperation
 from .model_base import ModelBase
+import quandl.model.dataset
 
 
 class Database(GetOperation, ListOperation, ModelBase):
@@ -58,12 +59,10 @@ class Database(GetOperation, ListOperation, ModelBase):
 
     def _bulk_download_path(self):
         url = self.default_path() + '/data'
-        url = Util.constructed_path(url, {'id': self.database_code})
+        url = Util.constructed_path(url, {'id': self.code})
         return url
 
     def datasets(self, **options):
-        params = {'database_code': self.database_code, 'query': '', 'page': 1}
+        params = {'database_code': self.code, 'query': '', 'page': 1}
         options = Util.merge_options('params', params, **options)
-        return Dataset.all(**options)
-
-from .dataset import Dataset
+        return quandl.model.dataset.Dataset.all(**options)

--- a/quandl/utils/api_key_util.py
+++ b/quandl/utils/api_key_util.py
@@ -1,0 +1,17 @@
+from quandl.api_config import ApiConfig
+import warnings
+import os
+
+
+class ApiKeyUtil(object):
+    @staticmethod
+    def init_api_key_from_args(params):
+        # set api key
+        if 'api_key' in params:
+            ApiConfig.api_key = params.pop('api_key')
+        # issue warning if api key was previously
+        # set and now is not
+        elif (ApiConfig.api_key is not None) and os.isatty(0):
+            warn_msg = "To ensure your api key is properly configured, please see: \
+https://github.com/quandl/quandl-python/blob/master/README.md"
+            warnings.warn(warn_msg, UserWarning)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ with open('LONG_DESCRIPTION.rst') as f:
 
 # Don't import quandl module here, since deps may not be installed
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'quandl'))
-from version import VERSION
+# can only import VERSION successfully after the above line
+# ignore flake8 warning that requires imports to be at the top
+from version import VERSION  # NOQA
 
 install_requires = [
     'pandas >= 0.14',
@@ -29,9 +31,7 @@ installs_for_two = [
     'pyasn1'
 ]
 
-ndg_httpsclient_version = 'ndg-httpsclient'
 if sys.version_info[0] < 3:
-    ndg_httpsclient_version = 'ndg-httpsclient == 0.3.0'
     install_requires += installs_for_two
 
 packages = [
@@ -58,8 +58,7 @@ setup(
         'nose',
         'httpretty',
         'mock',
-        'factory_boy',
-        ndg_httpsclient_version
+        'factory_boy'
     ],
     test_suite="nose.collector",
     packages=packages

--- a/test/factories/dataset.py
+++ b/test/factories/dataset.py
@@ -1,4 +1,5 @@
 import factory
+import six
 
 
 class DatasetFactory(factory.Factory):
@@ -13,7 +14,7 @@ class DatasetFactory(factory.Factory):
     name = 'National Stock Exchange of India'
     description = 'Stock and index data from the National Stock Exchange of India. '
     frequency = 'daily'
-    column_names = ['Date', 'column.1', 'column.2', 'column.3']
+    column_names = [six.u('Date'), six.u('column.1'), six.u('column.2'), six.u('column.3')]
     type = 'Time Series'
     premium = False
     refreshed_at = '2015-07-24T02:39:40.624Z'

--- a/test/helpers/httpretty_extension.py
+++ b/test/helpers/httpretty_extension.py
@@ -1,0 +1,14 @@
+from test.helpers.my_httpretty import MyHTTPretty
+import httpretty.core
+import httpretty
+
+# Substitute in our version
+HTTPretty = MyHTTPretty
+
+httpretty.core.httpretty = MyHTTPretty
+
+# May need to set other module-level attributes here, e.g. enable, reset etc,
+# depending on your needs
+httpretty.httpretty = MyHTTPretty
+httpretty.enable = MyHTTPretty.enable
+httpretty.disable = MyHTTPretty.disable

--- a/test/helpers/merged_datasets_helper.py
+++ b/test/helpers/merged_datasets_helper.py
@@ -1,0 +1,45 @@
+import re
+import json
+from quandl.model.dataset import Dataset
+from quandl.model.data import Data
+from quandl.model.data_list import DataList
+from test.factories.dataset import DatasetFactory
+from test.factories.dataset_data import DatasetDataFactory
+
+
+def setupDatasetsTest(unit_test, httpretty):
+    httpretty.reset()
+    httpretty.enable()
+
+    unit_test.dataset_data = {'dataset_data': DatasetDataFactory.build()}
+
+    dataset_data = DatasetDataFactory.build()
+    d_values = dataset_data.pop('data')
+    d_metadata = dataset_data
+    unit_test.data_list_obj = DataList(Data, d_values, d_metadata)
+
+    unit_test.nse_oil = {'dataset': DatasetFactory.build(
+        database_code='NSE', dataset_code='OIL')}
+
+    unit_test.goog_aapl = {'dataset': DatasetFactory.build(
+        database_code='GOOG', dataset_code='NASDAQ_AAPL')}
+
+    unit_test.goog_msft = {'dataset': DatasetFactory.build(
+        database_code='GOOG', dataset_code='NASDAQ_MSFT',
+        newest_available_date='2015-07-30', oldest_available_date='2013-01-01')}
+
+    unit_test.oil_obj = Dataset('NSE/OIL', unit_test.nse_oil['dataset'])
+    unit_test.aapl_obj = Dataset('GOOG/AAPL', unit_test.goog_aapl['dataset'])
+    unit_test.goog_obj = Dataset('GOOG/MSFT', unit_test.goog_msft['dataset'])
+
+    httpretty.register_uri(httpretty.GET,
+                           re.compile(
+                               'https://www.quandl.com/api/v3/datasets/.*/metadata'),
+                           responses=[httpretty.Response(body=json.dumps(dataset))
+                                      for dataset in
+                                      [unit_test.nse_oil, unit_test.goog_aapl,
+                                       unit_test.goog_msft]])
+    httpretty.register_uri(httpretty.GET,
+                           re.compile(
+                               'https://www.quandl.com/api/v3/datasets/.*/data'),
+                           body=json.dumps(unit_test.dataset_data))

--- a/test/helpers/my_httpretty.py
+++ b/test/helpers/my_httpretty.py
@@ -1,0 +1,31 @@
+# see: https://github.com/gabrielfalcao/HTTPretty/issues/242#issuecomment-160942608
+from httpretty import HTTPretty as OriginalHTTPretty
+
+try:
+    from requests.packages.urllib3.contrib.pyopenssl \
+        import inject_into_urllib3, extract_from_urllib3
+    pyopenssl_override = True
+except:
+    pyopenssl_override = False
+
+
+class MyHTTPretty(OriginalHTTPretty):
+    """ pyopenssl monkey-patches the default ssl_wrap_socket() function in the 'requests' library,
+    but this can stop the HTTPretty socket monkey-patching from working for HTTPS requests.
+    Our version extends the base HTTPretty enable() and disable() implementations to undo
+    and redo the pyopenssl monkey-patching, respectively.
+    """
+
+    @classmethod
+    def enable(cls):
+        OriginalHTTPretty.enable()
+        if pyopenssl_override:
+            # Take out the pyopenssl version - use the default implementation
+            extract_from_urllib3()
+
+    @classmethod
+    def disable(cls):
+        OriginalHTTPretty.disable()
+        if pyopenssl_override:
+            # Put the pyopenssl version back in place
+            inject_into_urllib3()

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -5,7 +5,7 @@ from quandl.errors.quandl_error import (
     AuthenticationError, ForbiddenError, InvalidRequestError,
     NotFoundError, ServiceUnavailableError)
 import unittest2
-import httpretty
+from test.helpers.httpretty_extension import httpretty
 import json
 from mock import patch, call
 

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,6 +1,6 @@
 import re
 import unittest2
-import httpretty
+from test.helpers.httpretty_extension import httpretty
 import json
 import datetime
 import pandas

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -7,7 +7,7 @@ except ImportError:
 
 import re
 import unittest2
-import httpretty
+from test.helpers.httpretty_extension import httpretty
 import json
 import six
 from quandl.errors.quandl_error import (InternalServerError, QuandlError)
@@ -29,7 +29,8 @@ class GetDatabaseTest(unittest2.TestCase):
                                re.compile(
                                    'https://www.quandl.com/api/v3/databases/*'),
                                body=json.dumps(database))
-        cls.db_instance = Database(database['database'])
+        cls.db_instance = Database(Database.get_code_from_meta(
+            database['database']), database['database'])
 
     @classmethod
     def tearDownClass(cls):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,6 +1,6 @@
 import re
 import unittest2
-import httpretty
+from test.helpers.httpretty_extension import httpretty
 import json
 import datetime
 from quandl.model.dataset import Dataset

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -1,0 +1,152 @@
+import unittest2
+from test.helpers.httpretty_extension import httpretty
+from test.helpers.merged_datasets_helper import setupDatasetsTest
+import pandas
+import numpy
+from mock import patch, call, Mock
+from quandl.model.dataset import Dataset
+from quandl.model.merged_dataset import MergedDataset
+from quandl.get import get
+from quandl.api_config import ApiConfig
+from quandl.connection import Connection
+
+
+class GetSingleDatasetTest(unittest2.TestCase):
+    @classmethod
+    def setUp(self):
+        # ensure api key is not set
+        ApiConfig.api_key = None
+        setupDatasetsTest(self, httpretty)
+
+    @classmethod
+    def tearDownClass(cls):
+        httpretty.disable()
+        httpretty.reset()
+
+    def test_returns_pandas_by_default(self):
+        result = get('NSE/OIL')
+        self.assertIsInstance(result, pandas.core.frame.DataFrame)
+
+    def test_returns_pandas_when_requested(self):
+        result = get('NSE/OIL', returns='pandas')
+        self.assertIsInstance(result, pandas.core.frame.DataFrame)
+
+    def test_returns_numpys_when_requested(self):
+        result = get('NSE/OIL', returns='numpy')
+        self.assertIsInstance(result, numpy.core.records.recarray)
+
+    def test_setting_api_key_config(self):
+        mock_connection = Mock(wraps=Connection)
+        with patch('quandl.connection.Connection.execute_request',
+                   new=mock_connection.execute_request) as mock:
+            ApiConfig.api_key = 'api_key_configured'
+            get('NSE/OIL')
+            # extract the headers passed to execute_request
+            actual_request_headers = mock.call_args[1]['headers']
+            self.assertEqual(actual_request_headers['x-api-token'], 'api_key_configured')
+
+    def test_sets_api_key_using_authtoken_arg(self):
+        get('NSE/OIL', authtoken='api_key')
+        self.assertEqual(ApiConfig.api_key, 'api_key')
+
+    def test_sets_api_key_using_api_key_arg(self):
+        get('NSE/OIL', api_key='api_key')
+        self.assertEqual(ApiConfig.api_key, 'api_key')
+
+    @patch.object(Dataset, 'data')
+    def test_query_params_are_formed_with_old_arg_names(self, mock_method):
+        get('NSE/OIL', authtoken='authtoken', trim_start='2001-01-01',
+            trim_end='2010-01-01', collapse='annual',
+            transformation='rdiff', rows=4, sort_order='desc')
+        self.assertEqual(mock_method.call_count, 1)
+        self.assertEqual(mock_method.mock_calls[0],
+                         call(params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
+                                      'collapse': 'annual', 'transform': 'rdiff',
+                                      'rows': 4, 'order': 'desc'}))
+
+    @patch.object(Dataset, 'data')
+    def test_query_params_are_formed_with_new_arg_names(self, mock_method):
+        get('NSE/OIL', api_key='authtoken', start_date='2001-01-01',
+            end_date='2010-01-01', collapse='annual',
+            transform='rdiff', rows=4, order='desc')
+        self.assertEqual(mock_method.call_count, 1)
+        self.assertEqual(mock_method.mock_calls[0],
+                         call(params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
+                                      'collapse': 'annual', 'transform': 'rdiff',
+                                      'rows': 4, 'order': 'desc'}))
+
+    @patch('quandl.model.data.Data.all')
+    def test_code_is_parsed(self, mock):
+        get('NSE/OIL')
+        expected = call(
+            params={'dataset_code': 'OIL', 'order': 'asc',
+                    'database_code': 'NSE'})
+        self.assertEqual(mock.call_args, expected)
+
+    @patch.object(Dataset, 'data')
+    def test_number_becomes_column_index(self, mock_method):
+        get('NSE/OIL.1')
+        self.assertEqual(mock_method.call_count, 1)
+        self.assertEqual(mock_method.mock_calls[0], call(params={'column_index': 1}))
+
+    @patch('quandl.model.data.Data.all')
+    def test_code_and_column_is_parsed_and_used(self, mock):
+        get('NSE/OIL.1')
+        expected = call(
+            params={'dataset_code': 'OIL', 'order': 'asc',
+                    'database_code': 'NSE', 'column_index': 1})
+        self.assertEqual(mock.call_args, expected)
+
+    def test_raise_error_when_non_numeric_column_index(self):
+        self.assertRaises(ValueError, lambda: get('NSE/OIL.notanumber'))
+
+
+class GetMultipleDatasetsTest(unittest2.TestCase):
+    @classmethod
+    def setUp(self):
+        # ensure api key is not set
+        ApiConfig.api_key = None
+        setupDatasetsTest(self, httpretty)
+
+    @classmethod
+    def tearDownClass(cls):
+        httpretty.disable()
+        httpretty.reset()
+
+    @patch('quandl.model.merged_dataset.MergedDataset._get_dataset')
+    def test_multiple_datasets_args_formed(self, mock):
+        # column_index is a dynamically added attribute
+        self.oil_obj.column_index = []
+        mock.return_value = self.oil_obj
+        get(['GOOG/NASDAQ_AAPL.1', 'GOOG/NASDAQ_MSFT.2', 'NSE/OIL'])
+        expected = [call(('GOOG/NASDAQ_AAPL', {'column_index': [1]})),
+                    call(('GOOG/NASDAQ_MSFT', {'column_index': [2]})),
+                    call('NSE/OIL')]
+        self.assertEqual(mock.call_args_list, expected)
+
+    @patch.object(MergedDataset, 'data')
+    def test_query_params_are_formed_with_old_arg_names(self, mock_method):
+        get(['GOOG/NASDAQ_AAPL.1', 'GOOG/NASDAQ_MSFT.2', 'NSE/OIL'],
+            authtoken='authtoken', trim_start='2001-01-01',
+            trim_end='2010-01-01', collapse='annual',
+            transformation='rdiff', rows=4, sort_order='desc')
+
+        self.assertEqual(mock_method.call_count, 1)
+        self.assertEqual(mock_method.mock_calls[0],
+                         call(handle_not_found_error=True,
+                              params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
+                                      'collapse': 'annual', 'transform': 'rdiff',
+                                      'rows': 4, 'order': 'desc'}))
+
+    @patch.object(MergedDataset, 'data')
+    def test_query_params_are_formed_with_new_arg_names(self, mock_method):
+        get(['GOOG/NASDAQ_AAPL.1', 'GOOG/NASDAQ_MSFT.2', 'NSE/OIL'],
+            api_key='authtoken', start_date='2001-01-01',
+            end_date='2010-01-01', collapse='annual',
+            transform='rdiff', rows=4, order='desc')
+        self.assertEqual(mock_method.call_count, 1)
+        self.assertEqual(mock_method.mock_calls[0],
+                         call(handle_not_found_error=True,
+                              params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
+                                      'collapse': 'annual', 'transform': 'rdiff',
+                                      'rows': 4, 'order': 'desc'}))

--- a/test/test_merged_dataset.py
+++ b/test/test_merged_dataset.py
@@ -1,58 +1,21 @@
-import re
 import unittest2
-import httpretty
-import json
+from test.helpers.httpretty_extension import httpretty
 import six
 import datetime
 import pandas
-from quandl.model.data import Data
-from quandl.model.data_list import DataList
-from quandl.model.merged_data_list import MergedDataList
 from quandl.model.dataset import Dataset
+from quandl.model.data import Data
+from quandl.model.merged_data_list import MergedDataList
 from quandl.model.merged_dataset import MergedDataset
 from mock import patch, call
-from test.factories.dataset import DatasetFactory
-from test.factories.dataset_data import DatasetDataFactory
+from test.helpers.merged_datasets_helper import setupDatasetsTest
 
 
 class GetMergedDatasetTest(unittest2.TestCase):
 
     @classmethod
     def setUp(self):
-        httpretty.reset()
-        httpretty.enable()
-
-        self.dataset_data = {'dataset_data': DatasetDataFactory.build()}
-
-        dataset_data = DatasetDataFactory.build()
-        d_values = dataset_data.pop('data')
-        d_metadata = dataset_data
-        self.data_list_obj = DataList(Data, d_values, d_metadata)
-
-        self.nse_oil = {'dataset': DatasetFactory.build(
-            database_code='NSE', dataset_code='OIL')}
-
-        self.goog_aapl = {'dataset': DatasetFactory.build(
-            database_code='GOOG', dataset_code='NASDAQ_AAPL')}
-
-        self.goog_msft = {'dataset': DatasetFactory.build(
-            database_code='GOOG', dataset_code='NASDAQ_MSFT',
-            newest_available_date='2015-07-30', oldest_available_date='2013-01-01')}
-
-        self.oil_obj = Dataset('NSE/OIL', self.nse_oil['dataset'])
-        self.aapl_obj = Dataset('GOOG/AAPL', self.goog_aapl['dataset'])
-        self.goog_obj = Dataset('GOOG/MSFT', self.goog_msft['dataset'])
-
-        httpretty.register_uri(httpretty.GET,
-                               re.compile(
-                                   'https://www.quandl.com/api/v3/datasets/.*/metadata'),
-                               responses=[httpretty.Response(body=json.dumps(dataset))
-                                          for dataset in
-                                          [self.nse_oil, self.goog_aapl, self.goog_msft]])
-        httpretty.register_uri(httpretty.GET,
-                               re.compile(
-                                   'https://www.quandl.com/api/v3/datasets/.*/data'),
-                               body=json.dumps(self.dataset_data))
+        setupDatasetsTest(self, httpretty)
 
     @classmethod
     def tearDownClass(cls):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@
 [flake8]
 max-line-length = 100
 exclude = __init__.py
-ignore = E402
 
 [tox]
 envlist = py2.7,py3.0,py3.1,py3.2,py3.3,py3.4,py3.5


### PR DESCRIPTION
Tracker Ticket: 
https://quandl.atlassian.net/browse/AP-1624

## Description:  
* backwards compatiblity `quandl.get` method, as described by the master README (https://github.com/quandl/quandl-python/blob/master/README.md)
* analyst `quandl.bulkdownload` method:
 * example: `quandl.bulkdownload('EOD', api_key='xxxxx', filename='/tmp/FOO.zip', download_type='partial')`
 * `download_type=` is optional and will default to `complete` if not specified
 * `filename=` is optional, if not specified will download to the current working directory
 * `api_key=` is optional, `api_key`can alternatively be set  with `quandl.ApiConfig.api_key='xxxxx'`


## Note to the reviewer:


## Is there a migration? 
(Running time? Downtime?)



## Dependency(if any): 
* updated class definitions from: https://github.com/quandl/quandl-python/pull/41, https://github.com/quandl/quandl-python/pull/44