### PR TITLE
Ap 1622/datatables for developers

### DIFF
--- a/quandl/__init__.py
+++ b/quandl/__init__.py
@@ -6,5 +6,38 @@ from .errors.quandl_error import *
 
 from .model.database import Database
 from .model.dataset import Dataset
+from .model.datatable import Datatable
 from .model.data import Data
 from .model.merged_dataset import MergedDataset
+import warnings
+import copy, os
+
+def get_table(code, **options):
+    paginate = None
+    if 'paginate' in options.keys(): paginate = options.pop('paginate')
+    data = None
+    page_count = 0
+    while True:
+        next_options = copy.deepcopy(options)
+        next_data = Datatable(code).data(params=next_options)
+
+        if data is None:
+            data = next_data
+        else:
+            data.extend(next_data)
+
+        if page_count >= ApiConfig.page_limit:
+            if os.isatty(0):
+                warnings.warn("data over page limit, rest data won't include", UserWarning)
+            break
+
+        next_cursor_id = next_data.meta['next_cursor_id']
+        if next_cursor_id is None:
+            break
+        elif paginate is not True and next_cursor_id is not None:
+            if os.isatty(0):
+                warnings.warn("This is the first page, for more pages, please use 'paginate=True'", UserWarning)
+            break
+        page_count = page_count + 1
+        options['qopts.cursor_id'] = next_cursor_id
+    return data.to_pandas()

--- a/quandl/api_config.py
+++ b/quandl/api_config.py
@@ -2,3 +2,4 @@ class ApiConfig:
     api_key = None
     api_base = 'https://www.quandl.com/api/v3'
     api_version = None
+    page_limit = 100

--- a/quandl/model/data.py
+++ b/quandl/model/data.py
@@ -8,7 +8,11 @@ from .data_mixin import DataMixin
 class Data(DataListOperation, DataMixin, ModelBase):
     def __init__(self, data, **options):
         self.meta = options['meta']
-        converted_column_names = list([Util.methodize(x) for x in options['meta']['column_names']])
+        if 'column_names' in options['meta'].keys():
+            the_list = [Util.methodize(x) for x in options['meta']['column_names']]
+            converted_column_names = list(the_list)
+        else:
+            converted_column_names = list([Util.methodize(x) for x in options['meta']['columns']])
         self._raw_data = Util.convert_to_dates(OrderedDict(list(zip(converted_column_names, data))))
 
     def __getattr__(self, k):

--- a/quandl/model/data_mixin.py
+++ b/quandl/model/data_mixin.py
@@ -8,10 +8,17 @@ class DataMixin(object):
         # ensure pandas gets a list of lists
         if data and isinstance(data, list) and not isinstance(data[0], list):
             data = [data]
-        df = pd.DataFrame(data=data, columns=self.column_names)
-        # ensure our first column of time series data is of pd.datetime
-        df[self.column_names[0]] = df[self.column_names[0]].apply(pd.to_datetime)
-        df.set_index(self.column_names[0], inplace=True)
+        if 'columns' in self.meta.keys():
+            df = pd.DataFrame(data=data, columns=self.columns)
+            for index, type in enumerate(self.column_types):
+                if type == 'Date':
+                    df[self.columns[index]] = df[self.columns[index]].apply(pd.to_datetime)
+        else:
+            df = pd.DataFrame(data=data, columns=self.column_names)
+            # ensure our first column of time series data is of pd.datetime
+            df[self.column_names[0]] = df[self.column_names[0]].apply(pd.to_datetime)
+            df.set_index(self.column_names[0], inplace=True)
+
         # unfortunately to_records() cannot handle unicode in 2.7
         df.index.name = str(df.index.name)
         # keep_column_indexes are 0 based, 0 is the first column

--- a/quandl/model/datatable.py
+++ b/quandl/model/datatable.py
@@ -1,0 +1,16 @@
+from quandl.operations.get import GetOperation
+from quandl.operations.list import ListOperation
+from quandl.util import Util
+from .model_base import ModelBase
+from .data import Data
+
+
+class Datatable(GetOperation, ListOperation, ModelBase):
+
+    @classmethod
+    def get_path(cls):
+        return "%s/metadata" % cls.default_path()
+
+    def data(self, **options):
+        updated_options = Util.convert_options(**options)
+        return Data.page(self, **updated_options)

--- a/quandl/model/model_base.py
+++ b/quandl/model/model_base.py
@@ -14,7 +14,8 @@ class ModelBase(object):
             raise AttributeError(k)
         elif k in self.__get_raw_data__():
             return self.__get_raw_data__()[k]
-        raise AttributeError(k)
+        else:
+            raise AttributeError(k)
 
     def __getitem__(self, k):
         return self.__get_raw_data__()[k]

--- a/quandl/model/model_list.py
+++ b/quandl/model/model_list.py
@@ -1,6 +1,13 @@
+from quandl.util import Util
+
+
 class ModelList(object):
     def __init__(self, klass, values, meta):
         self.klass = klass
+        if 'columns' in meta.keys():
+            meta['column_types'] = Util.convert_to_columns_list(meta['columns'], 'type')
+            meta['columns'] = Util.convert_to_columns_list(meta['columns'], 'name')
+
         if hasattr(klass, 'get_code_from_meta'):
             self.values = list([klass(klass.get_code_from_meta(x), x, meta=meta) for x in values])
         else:
@@ -14,6 +21,9 @@ class ModelList(object):
     def __getattr__(self, k):
         if k in self.meta:
             return self.meta[k]
+        elif k == 'column_names':
+            # keep datatable compatible with dataset
+            return self.meta['columns']
         elif hasattr(self.values, k):
             return getattr(self.values, k)
         raise AttributeError(k)

--- a/quandl/operations/data_list.py
+++ b/quandl/operations/data_list.py
@@ -17,5 +17,18 @@ class DataListOperation(ListOperation):
         return DataList(cls, values, metadata)
 
     @classmethod
+    def create_datatable_list_from_response(cls, data):
+        if len(data['datatable']['data']) > 0 \
+                and len(data['datatable']['columns']) != len(
+                    data['datatable']['data'][0]):
+            raise InvalidDataError(
+                'number of column names does not match number of data points in a row!',
+                response_data=data)
+        values = data['datatable'].pop('data')
+        metadata = {'columns': data['datatable']['columns'],
+                    'next_cursor_id': data['meta']['next_cursor_id']}
+        return DataList(cls, values, metadata)
+
+    @classmethod
     def list_path(cls):
         return "datasets/:database_code/:dataset_code/data"

--- a/quandl/operations/list.py
+++ b/quandl/operations/list.py
@@ -5,6 +5,7 @@ from quandl.model.paginated_list import PaginatedList
 
 
 class ListOperation(Operation):
+
     @classmethod
     def all(cls, **options):
         if 'params' not in options:
@@ -14,6 +15,16 @@ class ListOperation(Operation):
         response_data = r.json()
         Util.convert_to_dates(response_data)
         resource = cls.create_list_from_response(response_data)
+        return resource
+
+    @classmethod
+    def page(cls, datatable, **options):
+        params = {'id': str(datatable.code)}
+        path = Util.constructed_path(datatable.default_path(), params)
+        r = Connection.request('get', path, **options)
+        response_data = r.json()
+        Util.convert_to_dates(response_data)
+        resource = cls.create_datatable_list_from_response(response_data)
         return resource
 
     @classmethod

--- a/quandl/util.py
+++ b/quandl/util.py
@@ -51,3 +51,36 @@ class Util(object):
             elif isinstance(v, dict):
                 Util.convert_to_dates(v)
         return dic
+
+    @staticmethod
+    def convert_options(**options):
+        new_options = dict()
+        if 'params' in options.keys():
+            for key, value in options['params'].items():
+                is_dict = False
+                if isinstance(value, list):
+                    key = key + '[]'
+                else:
+                    if isinstance(value, dict) and value != {}:
+                        new_value = dict()
+                        is_dict = True
+                        old_key = key
+                        for k, v in value.items():
+                            key = key + '.' + k
+                            if isinstance(v, list):
+                                key = key + '[]'
+                            new_value[key] = v
+                            key = old_key
+
+                if is_dict:
+                    new_options.update(new_value)
+                else:
+                    new_options[key] = value
+        return {'params': new_options}
+
+    @staticmethod
+    def convert_to_columns_list(meta, type):
+        columns = []
+        for key in meta:
+            columns.extend([key[type]])
+        return columns

--- a/test/factories/datatable.py
+++ b/test/factories/datatable.py
@@ -1,0 +1,11 @@
+import factory
+
+
+class DatatableFactory(factory.Factory):
+
+    class Meta:
+        model = dict
+    id = factory.Sequence(lambda n: n)
+    vendor_code = factory.Sequence(lambda n: 'VENDOR_CODE{0}'.format(n))
+    datatable_code = factory.Sequence(lambda n: 'DATATABLE_CODE{0}'.format(n))
+    name = factory.Sequence(lambda n: 'DATATABLE{0}'.format(n))

--- a/test/factories/datatable_data.py
+++ b/test/factories/datatable_data.py
@@ -1,0 +1,13 @@
+import factory
+import six
+
+
+class DatatableDataFactory(factory.Factory):
+
+    class Meta:
+        model = dict
+    columns = [{six.u('name'):six.u('per_end_date'),six.u('type'):six.u('Date')},
+               {six.u('name'):six.u('ticker'),six.u('type'):six.u('String')},
+               {six.u('name'):six.u('tot_oper_exp'),six.u('type'):six.u('BigDecimal(11,4)')}]
+    data = [['2015-07-11', 'AAPL', 456.9], ['2015-07-13', 433.3],
+            ['2015-07-14', 'AAPL', 419.1], ['2015-07-15', 476.5]]

--- a/test/factories/datatable_meta.py
+++ b/test/factories/datatable_meta.py
@@ -1,0 +1,9 @@
+import factory
+
+
+class DatatableMetaFactory(factory.Factory):
+
+    class Meta:
+        model = dict
+
+    next_cursor_id = 'abc123'

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -7,8 +7,11 @@ import pandas
 import numpy
 import six
 from quandl.model.data import Data
+from quandl.model.datatable import Datatable
 from mock import patch, call
 from test.factories.dataset_data import DatasetDataFactory
+from test.factories.datatable_data import DatatableDataFactory
+from test.factories.datatable_meta import DatatableMetaFactory
 from quandl.errors.quandl_error import InvalidDataError
 
 
@@ -22,6 +25,7 @@ class DataTest(unittest2.TestCase):
                                meta={'column_names': cls.expected_column_names})
 
     def test_to_pandas_returns_pandas_dataframe_object(self):
+
         data = self.data_object.to_pandas()
         self.assertIsInstance(data, pandas.core.frame.DataFrame)
 
@@ -45,7 +49,6 @@ class DataTest(unittest2.TestCase):
 
     def test_meta_exists(self):
         self.assertIsNotNone(self.data_object.meta)
-
 
 class ListDataTest(unittest2.TestCase):
 

--- a/test/test_datatable.py
+++ b/test/test_datatable.py
@@ -1,0 +1,50 @@
+import re
+import unittest2
+import httpretty
+import json
+from quandl.model.datatable import Datatable
+from mock import patch, call
+from test.factories.datatable import DatatableFactory
+
+
+class GetDatatableDatasetTest(unittest2.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        httpretty.enable()
+        datatable = {'datatable': DatatableFactory.build(
+            vendor_code='ZACKS', datatable_code='FC')}
+        httpretty.register_uri(httpretty.GET,
+                               re.compile(
+                                   'https://www.quandl.com/api/v3/datatables/*'),
+                               body=json.dumps(datatable))
+        cls.datatable_instance = Datatable(datatable['datatable'])
+
+    @classmethod
+    def tearDownClass(cls):
+        httpretty.disable()
+        httpretty.reset()
+
+    @patch('quandl.connection.Connection.request')
+    def test_datatable_meatadata_calls_connection(self, mock):
+        Datatable('ZACKS/FC').data_fields()
+        expected = call('get', 'datatables/ZACKS/FC/metadata', params={})
+        self.assertEqual(mock.call_args, expected)
+
+    @patch('quandl.connection.Connection.request')
+    def test_datatable_data_calls_connection(self, mock):
+        Datatable('ZACKS/FC').data()
+        expected = call('get', 'datatables/ZACKS/FC', params={})
+        self.assertEqual(mock.call_args, expected)
+
+
+    def test_datatable_returns_datatable_object(self):
+        datatable = Datatable('ZACKS/FC')
+        self.assertIsInstance(datatable, Datatable)
+        self.assertEqual(datatable.vendor_code, 'ZACKS')
+        self.assertEqual(datatable.datatable_code, 'FC')
+
+    def test_dataset_column_names_match_expected(self):
+        metadata = Datatable('ZACKS/FC').data_fields()
+        self.assertItemsEqual(
+            metadata, [u'datatable_code', u'id', u'name', u'vendor_code'])

--- a/test/test_datatable_data.py
+++ b/test/test_datatable_data.py
@@ -1,0 +1,129 @@
+import re
+import unittest2
+import httpretty
+import json
+import datetime
+import pandas
+import numpy
+import six
+from quandl.model.data import Data
+from quandl.model.datatable import Datatable
+from mock import patch, call
+from test.factories.dataset_data import DatasetDataFactory
+from test.factories.datatable_data import DatatableDataFactory
+from test.factories.datatable_meta import DatatableMetaFactory
+from quandl.errors.quandl_error import InvalidDataError
+
+
+class DatatableDataTest(unittest2.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.expected_column_names = [six.u('per_end_date'),
+                                     six.u('ticker'),
+                                     six.u('tot_oper_exp')]
+        cls.expected_column_types = [six.u('Date'),
+                                     six.u('String'),
+                                     six.u('String')]
+        cls.data_object = Data(['2015-07-11', 'AAPL', 440.0],
+                               meta={'columns': cls.expected_column_names,
+                                     'column_types': cls.expected_column_types})
+
+    def test_to_pandas_returns_pandas_dataframe_object(self):
+        data = self.data_object.to_pandas()
+        self.assertIsInstance(data, pandas.core.frame.DataFrame)
+
+    # don't set dataFrame for datatable
+    def test_pandas_dataframe_index_is_datetime(self):
+        df = self.data_object.to_pandas()
+        self.assertEqual(df.index.name, 'None')
+
+    def test_to_numpys_returns_numpy_object(self):
+        data = self.data_object.to_numpy()
+        self.assertIsInstance(data, numpy.core.records.recarray)
+
+    def test_to_csv_returns_expected_csv(self):
+        data = self.data_object.to_csv()
+        expected = "None,per_end_date,ticker,tot_oper_exp\n0,2015-07-11,AAPL,440.0\n"
+        self.assertEqual(data, expected)
+
+    def test_column_names(self):
+        actual = self.data_object.columns
+        self.assertEqual(actual, self.expected_column_names)
+
+    def test_meta_exists(self):
+        self.assertIsNotNone(self.data_object.meta)
+
+class ListDatatableDataTest(unittest2.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        httpretty.enable()
+        datatable_data = {'datatable': DatatableDataFactory.build()}
+        meta = {'meta': DatatableMetaFactory.build()}
+        datatable_data.update(meta)
+        httpretty.register_uri(httpretty.GET,
+                               re.compile(
+                                   'https://www.quandl.com/api/v3/datatables/*'),
+                               body=json.dumps(datatable_data))
+        cls.expected_raw_data = []
+        cls.expected_list_values = []
+
+    @classmethod
+    def tearDownClass(cls):
+        httpretty.disable()
+        httpretty.reset()
+
+
+    @patch('quandl.connection.Connection.request')
+    def test_data_calls_connection(self, mock):
+        datatable = Datatable('ZACKS/FC')
+        Data.page(datatable, params={'ticker': ['AAPL','MSFT'], 'per_end_date': {'gte': {'2015-01-01' }}, 'qopts': {'columns': ['ticker', 'per_end_date']}})
+        expected = call('get', 'datatables/ZACKS/FC', params={'ticker': ['AAPL','MSFT'], 'per_end_date': {'gte': {'2015-01-01' }}, 'qopts': {'columns': ['ticker', 'per_end_date']}})
+        self.assertEqual(mock.call_args, expected)
+
+    def test_values_and_meta_exist(self):
+        datatable = Datatable('ZACKS/FC')
+        results = Data.page(datatable, params={})
+        self.assertIsNotNone(results.values)
+        self.assertIsNotNone(results.meta)
+
+    def test_to_pandas_returns_pandas_dataframe_object(self):
+        datatable = Datatable('ZACKS/FC')
+        results = Data.page(datatable, params={})
+        df = results.to_pandas()
+        self.assertIsInstance(df, pandas.core.frame.DataFrame)
+
+    # no index is set for datatable.to_pandas
+    def test_pandas_dataframe_index_is_none(self):
+        datatable = Datatable('ZACKS/FC')
+        results = Data.page(datatable, params={})
+        df = results.to_pandas()
+        self.assertEqual(df.index.name, 'None')
+
+    # if datatable has Date field then it should be convert to pandas datetime
+    def test_pandas_dataframe_date_field_is_datetime(self):
+        datatable = Datatable('ZACKS/FC')
+        results = Data.page(datatable, params={})
+        df = results.to_pandas()
+        self.assertIsInstance(df['per_end_date'][0], pandas.datetime)
+        self.assertIsInstance(df['per_end_date'][1], pandas.datetime)
+        self.assertIsInstance(df['per_end_date'][2], pandas.datetime)
+        self.assertIsInstance(df['per_end_date'][3], pandas.datetime)
+
+    def test_to_numpy_returns_numpy_object(self):
+        datatable = Datatable('ZACKS/FC')
+        results = Data.page(datatable, params={})
+        data = results.to_numpy()
+        self.assertIsInstance(data, numpy.core.records.recarray)
+
+    def test_to_csv_returns_expected_csv(self):
+        datatable = Datatable('ZACKS/FC')
+        results = Data.page(datatable, params={})
+        data = results.to_csv()
+        expected = "None,per_end_date,ticker,tot_oper_exp\n" + \
+                    "0,2015-07-11,AAPL,456.9\n" + \
+                    "1,2015-07-13,433.3,\n"  + \
+                    "2,2015-07-14,AAPL,419.1\n" + \
+                    "3,2015-07-15,476.5,\n"
+        self.assertEqual(data, expected)

--- a/test/test_get_table.py
+++ b/test/test_get_table.py
@@ -1,0 +1,39 @@
+import re
+import unittest2
+import httpretty
+import json
+from quandl.model.datatable import Datatable
+import pandas
+from mock import patch, call
+from test.factories.datatable import DatatableFactory
+from test.factories.datatable_data import  DatatableDataFactory
+from test.factories.datatable_meta import DatatableMetaFactory
+import quandl
+
+
+class GetDataTableTest(unittest2.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        httpretty.enable()
+        datatable = {'datatable': DatatableFactory.build(
+            vendor_code='ZACKS', datatable_code='FC')}
+        data = DatatableDataFactory.build()
+        datatable['datatable'].update(data)
+        meta = {'meta': DatatableMetaFactory.build()}
+        datatable.update(meta)
+        httpretty.register_uri(httpretty.GET,
+                               re.compile(
+                                   'https://www.quandl.com/api/v3/datatables*'),
+                               body=json.dumps(datatable))
+        cls.datatable_instance = Datatable(datatable['datatable'])
+
+    @classmethod
+    def tearDownClass(cls):
+        httpretty.disable()
+        httpretty.reset()
+
+    @patch('quandl.connection.Connection.request')
+    def test_datatable_returns_datatable_object(self,mock):
+        df = quandl.get_table('ZACKS/FC', params={})
+        self.assertIsInstance(df, pandas.core.frame.DataFrame)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -20,7 +20,7 @@ class ModelTest(unittest2.TestCase):
         self.assertEqual(self.model.here, 1)
 
     def test_throws_exception_when_attribute_does_not_exist(self):
-        self.assertRaises(AttributeError, lambda: self.model.blah)
+      self.assertRaises(AttributeError, lambda: self.model.blah)
 
     def test_to_list_returns_values(self):
         results = self.model.to_list()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,6 +4,12 @@ import six
 from quandl.util import Util
 
 
+# use this function just for test This function is define in python 2 but not at python 3
+def cmp(a, b):
+    a = sorted(a)
+    b = sorted(b)
+    return (a > b) - (a < b)
+
 class UtilTest(unittest2.TestCase):
 
     def test_methodize(self):
@@ -39,3 +45,14 @@ class UtilTest(unittest2.TestCase):
         result = Util.constructed_path(path, params)
         self.assertEqual(result, '/hello/bar/world/1')
         self.assertDictEqual(params, {'another': 'a'})
+
+    def test_convert_options(self):
+        options = {'params': {'ticker': ['AAPL','MSFT'], 'per_end_date': {'gte': {'2015-01-01' }}, 'qopts': {'columns': ['ticker', 'per_end_date'], 'per_page': 5}}}
+        expect_result = {'params': {'qopts.per_page': 5, 'per_end_date.gte': set(['2015-01-01']), 'ticker[]': ['AAPL', 'MSFT'], 'qopts.columns[]': ['ticker', 'per_end_date']}}
+        result = Util.convert_options(**options)
+        self.assertEqual(cmp(result,expect_result), 0)
+
+        options = {'params': {'ticker': 'AAPL', 'per_end_date': {'gte': {'2015-01-01' }}, 'qopts': {'columns': ['ticker', 'per_end_date']}}}
+        expect_result = {'params': {'per_end_date.gte': set(['2015-01-01']), 'ticker': 'AAPL', 'qopts.columns[]': ['ticker', 'per_end_date']}}
+        result = Util.convert_options(**options)
+        self.assertEqual(cmp(result,expect_result), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,4 @@ deps =
     httpretty
     factory_boy
     mock
+    ndg-httpsclient == 0.3.0


### PR DESCRIPTION
Jira Ticket:
- https://quandl.atlassian.net/browse/AP-1622
- https://quandl.atlassian.net/browse/AP-1623

## Description:
- Datatables for developers
- Datatables for analysts

## Note to the reviewer:
- when paginate, you need to get next_cursor_id by datatable.data.meta['next_cursor_id']


## Note to QA:
(Risk of breaking exisiting code, how to test the new code change)




## Dependency(if any):



## Screenshot(if any):
