### PR TITLE
remove user warning

### DIFF
--- a/quandl/utils/api_key_util.py
+++ b/quandl/utils/api_key_util.py
@@ -1,6 +1,4 @@
 from quandl.api_config import ApiConfig
-import warnings
-import os
 
 
 class ApiKeyUtil(object):
@@ -9,9 +7,3 @@ class ApiKeyUtil(object):
         # set api key
         if 'api_key' in params:
             ApiConfig.api_key = params.pop('api_key')
-        # issue warning if api key was previously
-        # set and now is not
-        elif (ApiConfig.api_key is not None) and os.isatty(0):
-            warn_msg = "To ensure your api key is properly configured, please see: \
-https://github.com/quandl/quandl-python/blob/master/README.md"
-            warnings.warn(warn_msg, UserWarning)


### PR DESCRIPTION
This warning message was suppose to only trigger when a user sets the api key via the analyst methods, and then unsets the key via the analysts methods (see conversion here: https://github.com/quandl/quandl-python/pull/42#discussion-diff-57623877)

Unfortunately it's not working as expected. talked to @mbasset and we will remove it for now.

The alternative fix would be to create a class, or an additional config in ApiConfig to save the state of the analyst methods, such that we can display the warning message when the api_key is set and unset via analyst methods - which can be implemented if needed if users complain of such behaviour