### PR TITLE
Reduce metadata calls

### DIFF
--- a/quandl/errors/quandl_error.py
+++ b/quandl/errors/quandl_error.py
@@ -54,3 +54,7 @@ class ForbiddenError(QuandlError):
 
 class InvalidDataError(QuandlError):
     pass
+
+
+class ColumnNotFound(QuandlError):
+    pass

--- a/quandl/get.py
+++ b/quandl/get.py
@@ -44,13 +44,15 @@ def get(dataset, **kwargs):
         dataset_args = _parse_dataset_code(dataset)
         if dataset_args['column_index'] is not None:
             kwargs.update({'column_index': dataset_args['column_index']})
-        data = Dataset(dataset_args['code']).data(params=kwargs)
+        data = Dataset(dataset_args['code']).data(params=kwargs, handle_column_not_found=True)
     # Array
     elif isinstance(dataset, list):
         args = _build_merged_dataset_args(dataset)
         # handle_not_found_error if set to True will add an empty DataFrame
         # for a non-existent dataset instead of raising an error
-        data = MergedDataset(args).data(params=kwargs, handle_not_found_error=True)
+        data = MergedDataset(args).data(params=kwargs,
+                                        handle_not_found_error=True,
+                                        handle_column_not_found=True)
     # If wrong format
     else:
         error = "Your dataset must either be specified as a string \

--- a/quandl/model/data_mixin.py
+++ b/quandl/model/data_mixin.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from quandl.errors.quandl_error import ColumnNotFound
 
 
 class DataMixin(object):
@@ -23,6 +24,7 @@ class DataMixin(object):
         df.index.name = str(df.index.name)
         # keep_column_indexes are 0 based, 0 is the first column
         if len(keep_column_indexes) > 0:
+            self._validate_col_index(df, keep_column_indexes)
             # need to decrement all our indexes by 1 because
             # Date is considered a column by our API, but in pandas,
             # it is the index, so column 0 is the first column after Date index
@@ -35,3 +37,10 @@ class DataMixin(object):
 
     def to_csv(self):
         return self.to_pandas().to_csv()
+
+    def _validate_col_index(self, df, keep_column_indexes):
+        num_columns = len(df.columns)
+        for col_index in keep_column_indexes:
+            if col_index > num_columns or col_index < 1:
+                raise ColumnNotFound('Requested column index %s does not exist'
+                                     % col_index)

--- a/quandl/model/merged_dataset.py
+++ b/quandl/model/merged_dataset.py
@@ -2,6 +2,7 @@ from more_itertools import unique_everseen
 import pandas as pd
 from six import string_types
 from .model_base import ModelBase
+from quandl.util import Util
 from .merged_data_list import MergedDataList
 from .data import Data
 from .dataset import Dataset
@@ -17,17 +18,7 @@ class MergedDataset(ModelBase):
 
     @property
     def column_names(self):
-        elements = []
-
-        for dataset in self.__dataset__():
-            for index, column_name in enumerate(dataset.column_names):
-                if self._include_column(dataset, index):
-                    if index > 0:
-                        elements.append(self._rename_columns(dataset, column_name))
-                    else:
-                        elements.append(column_name)
-
-        return list(unique_everseen(elements))
+        return self._merged_column_names_from(self.__dataset_objects__())
 
     @property
     def oldest_available_date(self):
@@ -38,61 +29,89 @@ class MergedDataset(ModelBase):
         return max(self._get_dataset_attribute('newest_available_date'))
 
     def data(self, **options):
-        dataset_data_list = [dataset.data(**options)
-                             for dataset in self.__dataset__()]
+        # if there is only one column_index, use the api to fetch
+        # else fetch all the data and filter column indexes requested locally
+        dataset_data_list = [self._get_dataset_data(dataset, **options)
+                             for dataset in self.__dataset_objects__()]
 
+        # build data frames and filter locally when necessary
         data_frames = [dataset_data.to_pandas(
-            keep_column_indexes=self.__dataset__()[index].column_index)
+            keep_column_indexes=self._keep_column_indexes(index))
             for index, dataset_data in enumerate(dataset_data_list)]
 
-        merged_data_frames = pd.DataFrame()
+        merged_data_frame = pd.DataFrame()
 
         for index, data_frame in enumerate(data_frames):
-            metadata = self.__dataset__()[index]
+            metadata = self.__dataset_objects__()[index]
+            # use code to prevent metadata api call
             data_frame.rename(
-                columns=lambda x: self._rename_columns(metadata, x), inplace=True)
-            merged_data_frames = pd.merge(
-                merged_data_frames, data_frame, right_index=True, left_index=True, how='outer')
+                columns=lambda x: self._rename_columns(metadata.code, x), inplace=True)
+            merged_data_frame = pd.merge(
+                merged_data_frame, data_frame, right_index=True, left_index=True, how='outer')
 
+        merged_data_metadata = self._build_data_meta(dataset_data_list, merged_data_frame)
+
+        # check if descending was explicitly set
+        # if set we need to sort in descending order
+        # since panda merged dataframe will
+        # by default sort everything in ascending
+        return MergedDataList(
+            Data, merged_data_frame, merged_data_metadata,
+            ascending=self._order_is_ascending(**options))
+
+    # for MergeDataset data calls
+    def _get_dataset_data(self, dataset, **options):
+        updated_options = options
+        # if we have only one column index, let the api
+        # handle the column filtering since the api supports this
+        if len(dataset.requested_column_indexes) == 1:
+            params = {'column_index': dataset.requested_column_indexes[0]}
+            # only change the options per request
+            updated_options = options.copy()
+            updated_options = Util.merge_options('params', params, **updated_options)
+        return dataset.data(**updated_options)
+
+    def _build_data_meta(self, dataset_data_list, df):
         merged_data_metadata = {}
-
         # for sanity check if list has items
         if dataset_data_list:
             # meta should be the same for every individual Dataset
             # request, just take the first one
             merged_data_metadata = dataset_data_list[0].meta.copy()
-            merged_data_metadata['column_names'] = self.column_names
 
-            # response will contain query param dates, if specified
-            # otherwise take the merged earliest/latest dates
-            if not self._in_query_param('start_date', **options):
-                merged_data_metadata['start_date'] = self.oldest_available_date
+            # set the start_date and end_date to
+            # the actual values we got back from data
+            num_rows = len(df.index)
+            if num_rows > 0:
+                merged_data_metadata['start_date'] = df.index[0].date()
+                merged_data_metadata['end_date'] = df.index[num_rows - 1].date()
 
-            if not self._in_query_param('end_date', **options):
-                merged_data_metadata['end_date'] = self.newest_available_date
+            # remove column_index if it exists because this would be per request data
+            merged_data_metadata.pop('column_index', None)
 
-        # check if descending was explicitly set
-        return MergedDataList(
-            Data, merged_data_frames, merged_data_metadata,
-            ascending=self._order_is_ascending(**options))
+            # don't use self.column_names to prevent metadata api call
+            # instead, get the column_names from the dataset_data_objects
+            merged_data_metadata['column_names'] = self._merged_column_names_from(dataset_data_list)
+        return merged_data_metadata
 
-    def _rename_columns(self, dataset_metadata, original_column_name):
-        return "%s/%s" % (dataset_metadata.database_code,
-                          dataset_metadata.dataset_code) + ' - ' + original_column_name
+    def _keep_column_indexes(self, index):
+        # no need to filter if we only have one column_index
+        # since leveraged the server to do the filtering
+        col_index = self.__dataset_objects__()[index].requested_column_indexes
+        if len(self.__dataset_objects__()[index].requested_column_indexes) == 1:
+            # empty array for no filtering
+            col_index = []
+        return col_index
+
+    def _rename_columns(self, code, original_column_name):
+        return code + ' - ' + original_column_name
 
     def _get_dataset_attribute(self, k):
         elements = []
-        for dataset in self.__dataset__():
+        for dataset in self.__dataset_objects__():
             elements.append(dataset.__get_raw_data__()[k])
 
         return list(unique_everseen(elements))
-
-    def _include_column(self, dataset_metadata, column_index):
-        # non-pandas/dataframe:
-        # keep column 0 around because we want to keep Date
-        if len(dataset_metadata.column_index) > 0 and column_index != 0:
-            return column_index in dataset_metadata.column_index
-        return True
 
     def _order_is_ascending(self, **options):
         return not (self._in_query_param('order', **options) and
@@ -102,37 +121,35 @@ class MergedDataset(ModelBase):
         return ('params' in options and
                 name in options['params'])
 
-    def __getattr__(self, k):
-        if k[0] == '_' and k != '_raw_data':
-            raise AttributeError(k)
-        elif hasattr(MergedDataset, k):
-            return super(MergedDataset, self).__getattr__(k)
-        elif k in self.__dataset__()[0].__get_raw_data__():
-            return self._get_dataset_attribute(k)
-        return super(MergedDataset, self).__getattr__(k)
+    # can take in a list of dataset_objects
+    # or a list of dataset_data_objects
+    def _merged_column_names_from(self, dataset_list):
+        elements = []
+        for idx_dataset, dataset in enumerate(dataset_list):
+            # require getting the code from the dataset object always
+            code = self.__dataset_objects__()[idx_dataset].code
+            for index, column_name in enumerate(dataset.column_names):
+                # only include column names that are not filtered out
+                # by specification of the column_indexes list
+                if self._include_column(dataset, index):
+                    # first index is the date, don't modify the date name
+                    if index > 0:
+                        elements.append(self._rename_columns(code, column_name))
+                    else:
+                        elements.append(column_name)
+        return list(unique_everseen(elements))
 
-    def __get_raw_data__(self):
-        self.__dataset__()
-        return ModelBase.__get_raw_data__(self)
+    def _include_column(self, dataset_metadata, column_index):
+        # non-pandas/dataframe:
+        # keep column 0 around because we want to keep Date
+        if (hasattr(dataset_metadata, 'requested_column_indexes') and
+            len(dataset_metadata.requested_column_indexes) > 0 and
+                column_index != 0):
+            return column_index in dataset_metadata.requested_column_indexes
+        return True
 
-    def __dataset__(self):
-        if self._datasets:
-            return self._datasets
-
-        if not isinstance(self.dataset_codes, list):
-            raise ValueError('dataset codes must be specified in a list')
-        # column_index is handled by individual dataset get's
-        if 'params' in self.options:
-            self.options['params'].pop("column_index", None)
-        self._datasets = list([self._get_dataset(dataset_code, **self.options)
-                               for dataset_code in self.dataset_codes])
-
-        # raw data will be initialized internally
-        self._initialize_raw_data(self._datasets)
-
-        return self._datasets
-
-    def _initialize_raw_data(self, datasets):
+    def _initialize_raw_data(self):
+        datasets = self.__dataset_objects__()
         self._raw_data = {}
         if not datasets:
             return self._raw_data
@@ -141,30 +158,33 @@ class MergedDataset(ModelBase):
             self._raw_data[k] = getattr(self, k)
         return self._raw_data
 
-    def _get_dataset(self, dataset_code, **options):
+    def _build_dataset_object(self, dataset_code, **options):
         options_copy = options.copy()
-        # data_codes are tuples e.g., ('GOOG/NASDAQ_AAPL', {'column_index":
-        # [1,2]}) or strings 'NSE/OIL'
+        # data_codes are tuples
+        # e.g., ('GOOG/NASDAQ_AAPL', {'column_index": [1,2]})
+        # or strings
+        # e.g., 'NSE/OIL'
         code = self._get_request_dataset_code(dataset_code)
 
         dataset = Dataset(code, None, **options_copy)
-        dataset.column_index = []
+        # save column_index param requested dynamically
+        # used later on to determine:
+        # if column_index is an array, fetch all data and use locally to filter columns
+        # if column_index is an empty array, fetch all data and don't filter columns
+        dataset.requested_column_indexes = self._get_req_dataset_col_indexes(dataset_code, code)
+        return dataset
+
+    def _get_req_dataset_col_indexes(self, dataset_code, code_str):
         # ensure if column_index dict is specified, value is a list
         params = self._get_request_params(dataset_code)
         if 'column_index' in params:
             column_index = params['column_index']
             if not isinstance(column_index, list):
                 raise ValueError(
-                    "%s : column_index needs to be a list of integer indexes" % code)
-            dataset.column_index = column_index
-        # if column_indexes are specified, check that they actually exist
-        max_column_index = len(dataset.column_names) - 1
-        for index in dataset.column_index:
-            if index > max_column_index or index < 1:
-                raise ValueError("%s : requested index %s is out of range. \
-                                  Min index is 1 and Max index is %s" % (code, index,
-                                                                         max_column_index))
-        return dataset
+                    "%s : column_index needs to be a list of integer indexes" % code_str)
+            return column_index
+        # default, no column indexes to filter
+        return []
 
     def _get_request_dataset_code(self, dataset_code):
         if isinstance(dataset_code, tuple):
@@ -178,3 +198,31 @@ class MergedDataset(ModelBase):
         if isinstance(dataset_code, tuple):
             return dataset_code[1]
         return {}
+
+    def __getattr__(self, k):
+        if k[0] == '_' and k != '_raw_data':
+            raise AttributeError(k)
+        elif hasattr(MergedDataset, k):
+            return super(MergedDataset, self).__getattr__(k)
+        elif k in self.__dataset_objects__()[0].__get_raw_data__():
+            return self._get_dataset_attribute(k)
+        return super(MergedDataset, self).__getattr__(k)
+
+    def __get_raw_data__(self):
+        if self._raw_data is None:
+            self._initialize_raw_data()
+        return ModelBase.__get_raw_data__(self)
+
+    def __dataset_objects__(self):
+        if self._datasets:
+            return self._datasets
+
+        if not isinstance(self.dataset_codes, list):
+            raise ValueError('dataset codes must be specified in a list')
+        # column_index is handled by individual dataset get's
+        if 'params' in self.options:
+            self.options['params'].pop("column_index", None)
+        self._datasets = list([self._build_dataset_object(dataset_code, **self.options)
+                               for dataset_code in self.dataset_codes])
+
+        return self._datasets

--- a/test/helpers/merged_datasets_helper.py
+++ b/test/helpers/merged_datasets_helper.py
@@ -1,5 +1,6 @@
 import re
 import jsondate as json
+import six
 
 from quandl.model.dataset import Dataset
 from quandl.model.data import Data
@@ -13,6 +14,13 @@ def setupDatasetsTest(unit_test, httpretty):
     httpretty.enable()
 
     unit_test.dataset_data = {'dataset_data': DatasetDataFactory.build()}
+
+    # mock out calls with column_index query param
+    # NOTE: this will always return 'column.1' as the column name
+    single_col_data = DatasetDataFactory.build(column_names=[six.u('Date'), six.u('column.1')],
+                                               data=[['2015-07-11', 444.3], ['2015-07-13', 433.3],
+                                                     ['2015-07-14', 437.5], ['2015-07-15', 440.0]])
+    unit_test.single_dataset_data = {'dataset_data': single_col_data}
 
     dataset_data = DatasetDataFactory.build()
     d_values = dataset_data.pop('data')
@@ -29,9 +37,14 @@ def setupDatasetsTest(unit_test, httpretty):
         database_code='GOOG', dataset_code='NASDAQ_MSFT',
         newest_available_date='2015-07-30', oldest_available_date='2013-01-01')}
 
+    unit_test.single_col = {'dataset': DatasetFactory.build(
+        database_code='SINGLE', dataset_code='COLUMN',
+        newest_available_date='2015-07-30', oldest_available_date='2013-01-01')}
+
     unit_test.oil_obj = Dataset('NSE/OIL', unit_test.nse_oil['dataset'])
     unit_test.aapl_obj = Dataset('GOOG/AAPL', unit_test.goog_aapl['dataset'])
     unit_test.goog_obj = Dataset('GOOG/MSFT', unit_test.goog_msft['dataset'])
+    unit_test.single_col_obj = Dataset('SINGLE/COLUMN', unit_test.single_col['dataset'])
 
     httpretty.register_uri(httpretty.GET,
                            re.compile(
@@ -40,7 +53,18 @@ def setupDatasetsTest(unit_test, httpretty):
                                       for dataset in
                                       [unit_test.nse_oil, unit_test.goog_aapl,
                                        unit_test.goog_msft]])
+    # mock our query param column_index request
+    httpretty.register_uri(httpretty.GET,
+                           "https://www.quandl.com/api/v3/datasets/SINGLE/COLUMN/data",
+                           body=json.dumps(unit_test.single_dataset_data))
+    httpretty.register_uri(httpretty.GET,
+                           "https://www.quandl.com/api/v3/datasets/GOOG/NASDAQ_AAPL/data",
+                           body=json.dumps(unit_test.dataset_data))
     httpretty.register_uri(httpretty.GET,
                            re.compile(
-                               'https://www.quandl.com/api/v3/datasets/.*/data'),
+                               'https://www.quandl.com/api/v3/datasets/NSE/OIL/data'),
+                           body=json.dumps(unit_test.dataset_data))
+    httpretty.register_uri(httpretty.GET,
+                           re.compile(
+                               'https://www.quandl.com/api/v3/datasets/GOOG/NASDAQ_MSFT/data'),
                            body=json.dumps(unit_test.dataset_data))

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -60,7 +60,8 @@ class GetSingleDatasetTest(unittest2.TestCase):
             transformation='rdiff', rows=4, sort_order='desc')
         self.assertEqual(mock_method.call_count, 1)
         self.assertEqual(mock_method.mock_calls[0],
-                         call(params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
+                         call(handle_column_not_found=True,
+                              params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
                                       'collapse': 'annual', 'transform': 'rdiff',
                                       'rows': 4, 'order': 'desc'}))
 
@@ -71,7 +72,8 @@ class GetSingleDatasetTest(unittest2.TestCase):
             transform='rdiff', rows=4, order='desc')
         self.assertEqual(mock_method.call_count, 1)
         self.assertEqual(mock_method.mock_calls[0],
-                         call(params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
+                         call(handle_column_not_found=True,
+                              params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
                                       'collapse': 'annual', 'transform': 'rdiff',
                                       'rows': 4, 'order': 'desc'}))
 
@@ -87,7 +89,8 @@ class GetSingleDatasetTest(unittest2.TestCase):
     def test_number_becomes_column_index(self, mock_method):
         get('NSE/OIL.1')
         self.assertEqual(mock_method.call_count, 1)
-        self.assertEqual(mock_method.mock_calls[0], call(params={'column_index': 1}))
+        self.assertEqual(mock_method.mock_calls[0],
+                         call(handle_column_not_found=True, params={'column_index': 1}))
 
     @patch('quandl.model.data.Data.all')
     def test_code_and_column_is_parsed_and_used(self, mock):
@@ -113,10 +116,10 @@ class GetMultipleDatasetsTest(unittest2.TestCase):
         httpretty.disable()
         httpretty.reset()
 
-    @patch('quandl.model.merged_dataset.MergedDataset._get_dataset')
+    @patch('quandl.model.merged_dataset.MergedDataset._build_dataset_object')
     def test_multiple_datasets_args_formed(self, mock):
-        # column_index is a dynamically added attribute
-        self.oil_obj.column_index = []
+        # requested_column_indexes is a dynamically added attribute
+        self.oil_obj.requested_column_indexes = []
         mock.return_value = self.oil_obj
         get(['GOOG/NASDAQ_AAPL.1', 'GOOG/NASDAQ_MSFT.2', 'NSE/OIL'])
         expected = [call(('GOOG/NASDAQ_AAPL', {'column_index': [1]})),
@@ -133,7 +136,7 @@ class GetMultipleDatasetsTest(unittest2.TestCase):
 
         self.assertEqual(mock_method.call_count, 1)
         self.assertEqual(mock_method.mock_calls[0],
-                         call(handle_not_found_error=True,
+                         call(handle_not_found_error=True, handle_column_not_found=True,
                               params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
                                       'collapse': 'annual', 'transform': 'rdiff',
                                       'rows': 4, 'order': 'desc'}))
@@ -146,7 +149,7 @@ class GetMultipleDatasetsTest(unittest2.TestCase):
             transform='rdiff', rows=4, order='desc')
         self.assertEqual(mock_method.call_count, 1)
         self.assertEqual(mock_method.mock_calls[0],
-                         call(handle_not_found_error=True,
+                         call(handle_not_found_error=True, handle_column_not_found=True,
                               params={'start_date': '2001-01-01', 'end_date': '2010-01-01',
                                       'collapse': 'annual', 'transform': 'rdiff',
                                       'rows': 4, 'order': 'desc'}))


### PR DESCRIPTION
Tracker Ticket: 
https://quandl.atlassian.net/browse/AP-1631

## Description:
* Minimize Dataset data fetched from server when performing a `MergedDataset([...]).data()` call:
 * If only one column index is requested, pass as query param `column_index=x` so that the server can give us back that one column
 * For more than 1 column specified, fetch all the data from the server, and filter out on the client side the columns the user has requested
   * NOTE: We have to handle multiple column index per Dataset in a MergedDataset on the client side because the API does not support multiple column_indexes for a Dataset data fetch
* Don't make metadata calls when calling `MergedDataset('[]').data()`
* Make metadata call only when user asks for an attribute of the `MergedDataset`, e.g., `MergedDataset([...]).name`
* MergedDataList (which is the class that holds the dataset data response data for a MergedDataset):
 * instead of getting the `start_date` and `end_date` from the metadata, just set these values to what we see in the actual data we got back via the merged dataframe
* Validations:
 * Do not perform client side validation of requested column indexes when performing MergedDataset().data()
 * Perform the validation after we retrieve the data
 * This prevents the forced
* Analyst `Quandl.get([....])`
 * Fail silently when making single dataset calls where the column does not exist (i.e., insert a Not Found empty column in the data frame)
 * Fail silently when making multiple dataset calls where the column does not exist
 * Fail silently when dataset does not exist ONLY in multiple dataset scenario
 * Raise a `NotFoundError` for single dataset call and dataset does not exist
 * Fail silently means to insert an empty DataFrame column whenever column(s) fails to be retrieved
* Developer flow MergedDataset and Dataset:
 * Raise a `ColumnNotFound` when dataset column does not exist
 * Raise a `NotFoundError` (as before) when dataset does not exist

## Note to the reviewer:


## Note to QA:
* Lots can break from this PR
