### PR TITLE
handle non-json non quandl error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.1 - 2016-05-25
+
+* Handle unexpected errors
+
 ### 3.0.0 - 2016-04-22
 
 * Datatables for developers

--- a/quandl/connection.py
+++ b/quandl/connection.py
@@ -53,12 +53,18 @@ class Connection:
     def parse(cls, response):
         try:
             return response.json()
-        except ValueError as e:
-            raise QuandlError(str(e), response.status_code, response.text)
+        except ValueError:
+            raise QuandlError(http_status=response.status_code, http_body=response.text)
 
     @classmethod
     def handle_api_error(cls, resp):
         error_body = cls.parse(resp)
+
+        # if our app does not form a proper quandl_error response
+        # throw generic error
+        if 'quandl_error' not in error_body:
+            raise QuandlError(http_status=resp.status_code, http_body=resp.text)
+
         code = error_body['quandl_error']['code']
         message = error_body['quandl_error']['message']
         prog = re.compile('^QE([a-zA-Z])x')

--- a/quandl/errors/quandl_error.py
+++ b/quandl/errors/quandl_error.py
@@ -1,12 +1,16 @@
 class QuandlError(RuntimeError):
-    def __init__(self, quandl_message, http_status=None, http_body=None, http_headers=None,
+    GENERIC_ERROR_MESSAGE = 'Something went wrong. Please try again. \
+If you continue to have problems, please contact us at connect@quandl.com.'
+
+    def __init__(self, quandl_message=None, http_status=None, http_body=None, http_headers=None,
                  quandl_error_code=None, response_data=None):
         self.http_status = http_status
         self.http_body = http_body
         self.http_headers = http_headers if http_headers is not None else {}
 
         self.quandl_error_code = quandl_error_code
-        self.quandl_message = quandl_message
+        self.quandl_message = quandl_message if quandl_message is not None \
+            else self.GENERIC_ERROR_MESSAGE
         self.response_data = response_data
 
     def __str__(self):

--- a/quandl/version.py
+++ b/quandl/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.0.0'
+VERSION = '3.0.1'

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -67,6 +67,6 @@ class ConnectionTest(unittest2.TestCase):
                                  'accept': ('application/json, '
                                             'application/vnd.quandl+json;version=2015-04-09'),
                                  'request-source': 'python',
-                                 'request-source-version': '3.0.0'},
+                                 'request-source-version': '3.0.1'},
                         params={'per_page': 10, 'page': 2})
         self.assertEqual(mock.call_args, expected)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -44,6 +44,16 @@ class ConnectionTest(unittest2.TestCase):
             QuandlError, lambda: Connection.request('get', 'databases'))
 
     @httpretty.activate
+    def test_non_quandl_error(self):
+        httpretty.register_uri(httpretty.GET,
+                               "https://www.quandl.com/api/v3/databases",
+                               body=json.dumps(
+                                {'foobar':
+                                 {'code': 'blah', 'message': 'something went wrong'}}), status=500)
+        self.assertRaises(
+            QuandlError, lambda: Connection.request('get', 'databases'))
+
+    @httpretty.activate
     @patch('quandl.connection.Connection.execute_request')
     def test_build_request(self, mock):
         ApiConfig.api_key = 'api_token'


### PR DESCRIPTION
## Tracker Ticket
https://quandl.atlassian.net/browse/AP-1808

## Description
* For non-standard error responses, e.g., non-json or non quandl_error responses (responses that do not have the root key `quandl_error` in json format), show a generic error message to users
* NOTE: this will also probably cover the case where the response body is empty - as we will encounter a json parse error (though i was not able to repro a situation where the response body was empty)

## Note to the reviewer
* see comments here: https://quandl.atlassian.net/browse/AP-1861 on how non standard response body may come about

## Note to QA


## Dependency

* None