### PR TITLE
change the way the api key path is generated

### DIFF
--- a/quandl/api_config.py
+++ b/quandl/api_config.py
@@ -1,5 +1,6 @@
 import os
 
+
 class ApiConfig:
     api_key = None
     api_protocol = 'https://'
@@ -28,14 +29,10 @@ def read_key(filename=None):
     if filename is None:
         filename = os.path.join(os.path.expanduser('~'), '.quandl_apikey')
 
-    try:
-        fileptr = open(filename, 'r')
-        apikey = fileptr.read()
-        fileptr.close()
+    with open(filename, 'r') as f:
+        apikey = f.read()
 
-        if apikey:
-            ApiConfig.api_key = apikey
-        else:
-            raise Exception("File '{:s}' is empty.".format(filename))
-    except ValueError:
-        raise Exception("File '{:s}' not found.".format(filename))
+    if not apikey:
+        raise ValueError("File '{:s}' is empty.".format(filename))
+
+    ApiConfig.api_key = apikey

--- a/quandl/api_config.py
+++ b/quandl/api_config.py
@@ -1,3 +1,5 @@
+import os
+
 class ApiConfig:
     api_key = None
     api_protocol = 'https://'
@@ -14,8 +16,7 @@ class ApiConfig:
 
 def save_key(apikey, filename=None):
     if filename is None:
-        import pathlib
-        filename = str(pathlib.Path.home()) + "/.quandl_apikey"
+        filename = os.path.join(os.path.expanduser('~'), '.quandl_apikey')
 
     fileptr = open(filename, 'w')
     fileptr.write(apikey)
@@ -25,8 +26,7 @@ def save_key(apikey, filename=None):
 
 def read_key(filename=None):
     if filename is None:
-        import pathlib
-        filename = str(pathlib.Path.home()) + "/.quandl_apikey"
+        filename = os.path.join(os.path.expanduser('~'), '.quandl_apikey')
 
     try:
         fileptr = open(filename, 'r')

--- a/quandl/version.py
+++ b/quandl/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.4.5'
+VERSION = '3.4.6'


### PR DESCRIPTION
A fix for of https://github.com/quandl/quandl-python/issues/127