### PR TITLE
dev/only support python 3.5 and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install flake8
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### 3.5.0 - 2019-12-03
+
+  Drop support for Python 2 and Python < 3.5. See [here for more info](./DROP_PYTHON_EOL_SUPPORT.md).
+
+### 3.4.9 - 2019-12-03
+
+* This version is the last `quandl` version to support Python 2 or < 3.5. All future `quandl` package releases will only support Python >= 3.5.
+
+  If you're still using Python 2 or < 3.5, you'll need to stay at this version. 
+
+  If you're using Python >= 3.5, its recommended you perform a `pip install --upgrade quandl` to grab the newest
+  version.
+
 ### 3.4.8 - 2019-05-03
 
 * Add config to verify SSL certs. Verification on by default. (#135)

--- a/DROP_PYTHON_EOL_SUPPORT.md
+++ b/DROP_PYTHON_EOL_SUPPORT.md
@@ -1,0 +1,12 @@
+### Overview
+
+Python 2 and < 3.5 will be or have already reached their end of life. Therefore, new `quandl` releases 
+will only support Python versions >= 3.5.
+
+* `quandl` versions less than `3.5.0` will only support Python 2 and Python < 3.5.
+* `quandl` versions greater than or equal to `3.5.0` will only support Python >= 3.5
+
+If you're using Python 2 or < 3.5, you'll need to stay at `quandl 3.4.9` or lower.
+If you're using Python >= 3.5, its recommended to perform a `pip install --upgrade quandl` to grab the
+latest and greatest.
+

--- a/quandl/version.py
+++ b/quandl/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.4.8'
+VERSION = '3.5.0'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ INSTALL_REQUIRES = [
     'inflection >= 0.3.1',
     'python-dateutil',
     'six',
-    'more-itertools <= 5.0.0'
+    'more-itertools'
 ]
 
 INSTALLS_FOR_TWO = [
@@ -36,7 +36,7 @@ if sys.version_info[0] < 3:
 
 TEST_REQUIRES = [
         'flake8',
-        'nose <= 1.3.7',
+        'nose',
         'httpretty',
         'mock',
         'factory_boy',

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ import sys
 
 if sys.version_info[:2] < (3, 5):
     raise ImportError("""
-    This version of quandl-python no longer supports python versions less than 3.5.0. If you're
+    This version of quandl no longer supports python versions less than 3.5.0. If you're
     reading this message your pip and/or setuptools are outdated. Please run the following to
     update them:
 
     pip install pip setuptools --upgrade
 
-    Then try to reinstall quandl-python:
+    Then try to reinstall quandl:
 
     pip install quandl
     """)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,18 @@
 import os
 import sys
 
+if sys.version_info[:2] < (3, 5):
+    raise ImportError("""
+    This version of quandl-python no longer supports python versions less than 3.5.0. If you're reading this message
+    your pip and/or setuptools are outdated. Please run the following to update them:
+    
+    pip install pip setuptools --upgrade
+    
+    Then try to reinstall quandl-python
+    
+    pip install quandl
+    """)
+
 try:
     from setuptools import setup
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@ import sys
 
 if sys.version_info[:2] < (3, 5):
     raise ImportError("""
-    This version of quandl-python no longer supports python versions less than 3.5.0. If you're reading this message
-    your pip and/or setuptools are outdated. Please run the following to update them:
-    
+    This version of quandl-python no longer supports python versions less than 3.5.0. If you're
+    reading this message your pip and/or setuptools are outdated. Please run the following to
+    update them:
+
     pip install pip setuptools --upgrade
-    
-    Then try to reinstall quandl-python
-    
+
+    Then try to reinstall quandl-python:
+
     pip install quandl
     """)
 

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,14 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8"
     ],
     install_requires=INSTALL_REQUIRES,
     tests_require=TEST_REQUIRES,
+    python_requires='>= 3.5',
     test_suite="nose.collector",
     packages=PACKAGES
 )

--- a/setup.py
+++ b/setup.py
@@ -37,15 +37,6 @@ INSTALL_REQUIRES = [
     'more-itertools'
 ]
 
-INSTALLS_FOR_TWO = [
-    'pyOpenSSL',
-    'ndg-httpsclient',
-    'pyasn1'
-]
-
-if sys.version_info[0] < 3:
-    INSTALL_REQUIRES += INSTALLS_FOR_TWO
-
 TEST_REQUIRES = [
         'flake8',
         'nose',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 [tox]
-envlist = py2.7,py3.4,py3.5,py3.6
+envlist = py3.5,py3.6,py3.7,py3.8
 
 [testenv]
 commands =


### PR DESCRIPTION
From now on master will only support python versions 3.5 and up now that python 3.0 -> 3.4 is EOL and python 2.7 is soon to be as well.