### PR TITLE
Format setup.py to be more readable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
     from distutils.core import setup
 
 with open('LONG_DESCRIPTION.rst') as f:
-    long_description = f.read()
+    LONG_DESCRIPTION = f.read()
 
 # Don't import quandl module here, since deps may not be installed
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'quandl'))
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'quandl'))
 # ignore flake8 warning that requires imports to be at the top
 from version import VERSION  # NOQA
 
-install_requires = [
+INSTALL_REQUIRES = [
     'pandas >= 0.14',
     'numpy >= 1.8',
     'requests >= 2.7.0',
@@ -25,16 +25,26 @@ install_requires = [
     'more-itertools <= 5.0.0'
 ]
 
-installs_for_two = [
+INSTALLS_FOR_TWO = [
     'pyOpenSSL',
     'ndg-httpsclient',
     'pyasn1'
 ]
 
 if sys.version_info[0] < 3:
-    install_requires += installs_for_two
+    INSTALL_REQUIRES += INSTALLS_FOR_TWO
 
-packages = [
+TEST_REQUIRES = [
+        'flake8',
+        'nose <= 1.3.7',
+        'httpretty',
+        'mock',
+        'factory_boy',
+        'jsondate',
+        'parameterized'
+]
+
+PACKAGES = [
     'quandl',
     'quandl.errors',
     'quandl.model',
@@ -46,7 +56,7 @@ setup(
     name='Quandl',
     description='Package for quandl API access',
     keywords=['quandl', 'API', 'data', 'financial', 'economic'],
-    long_description=long_description,
+    long_description=LONG_DESCRIPTION,
     version=VERSION,
     author='Quandl',
     author_email='connect@quandl.com',
@@ -61,16 +71,8 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ],
-    install_requires=install_requires,
-    tests_require=[
-        'flake8',
-        'nose <= 1.3.7',
-        'httpretty',
-        'mock',
-        'factory_boy',
-        'jsondate',
-        'parameterized'
-    ],
+    install_requires=INSTALL_REQUIRES,
+    tests_require=TEST_REQUIRES,
     test_suite="nose.collector",
-    packages=packages
+    packages=PACKAGES
 )


### PR DESCRIPTION
Preliminary reformatting before we perform branching for different python support

- Moves values out of `setup()` and into constants