### PR TITLE
travis.yml: unbreak python 3.5 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.8"
 install:
   - pip install flake8
+  - pip install -r requirements.txt
 script:
   - flake8
   - python -W always setup.py -q test


### PR DESCRIPTION
Fix travis by relying on pip for install requirements.  Fixes an issue
where running `python test` would fail for python 3.5 as it would
install latest dependencies, of which may be incompatible with python
3.5.

Signed-off-by: Jamie Couture <jamie@quandl.com>