### PR TITLE
adjust GET request url length max value

### DIFF
--- a/quandl/utils/request_type_util.py
+++ b/quandl/utils/request_type_util.py
@@ -8,10 +8,10 @@ from quandl.api_config import ApiConfig
 
 class RequestType(object):
     """ Determines whether a request should be made using a GET or a POST request.
-    Default limit of 8000 is set here as it appears to be the maximum for many
+    Default limit of 6300 is set here as it appears to be the maximum for many
     webservers.
     """
-    MAX_URL_LENGTH_FOR_GET = 8000
+    MAX_URL_LENGTH_FOR_GET = 6300
     USE_GET_REQUEST = True  # This is used to simplify testing code
 
     @classmethod


### PR DESCRIPTION
Adjust the max url length threshold so that long GET urls that might get 414 to use POST instead.
More info in ticket