### PR TITLE
drop support for python 3.5

### DIFF
--- a/DROP_PYTHON_EOL_SUPPORT.md
+++ b/DROP_PYTHON_EOL_SUPPORT.md
@@ -1,12 +1,13 @@
 ### Overview
 
-Python 2 and < 3.5 will be or have already reached their end of life. Therefore, new `quandl` releases 
-will only support Python versions >= 3.5.
+Python 2 and < 3.6 will be or have already reached their end of life. Therefore, new `quandl` releases
+will only support Python versions >= 3.6.
 
 * `quandl` versions less than `3.5.0` will only support Python 2 and Python < 3.5.
-* `quandl` versions greater than or equal to `3.5.0` will only support Python >= 3.5
+* `quandl` versions greater than or equal to `3.6.0` will only support Python >= 3.6
 
 If you're using Python 2 or < 3.5, you'll need to stay at `quandl 3.4.9` or lower.
-If you're using Python >= 3.5, its recommended to perform a `pip install --upgrade quandl` to grab the
+If you're using 3.5.x, you'll need to stay at `quandl 3.5.x`.
+If you're using Python >= 3.6, its recommended to perform a `pip install --upgrade quandl` to grab the
 latest and greatest.
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-if sys.version_info[:2] < (3, 5):
+if sys.version_info[:2] < (3, 6):
     raise ImportError("""
-    This version of quandl no longer supports python versions less than 3.5.0. If you're
+    This version of quandl no longer supports python versions less than 3.6.0. If you're
     reading this message your pip and/or setuptools are outdated. Please run the following to
     update them:
 
@@ -72,14 +72,13 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8"
     ],
     install_requires=INSTALL_REQUIRES,
     tests_require=TEST_REQUIRES,
-    python_requires='>= 3.5',
+    python_requires='>= 3.6',
     test_suite="nose.collector",
     packages=PACKAGES
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 [tox]
-envlist = py3.5,py3.6,py3.7,py3.8
+envlist = py3.6,py3.7,py3.8
 
 [testenv]
 commands =


### PR DESCRIPTION
Update documentation and setup.py to drop support for EOL python 3.5.

Signed-off-by: Jamie Couture <jamie@quandl.com>