### PR TITLE
Support datetimes for pit

### DIFF
--- a/FOR_ANALYSTS.md
+++ b/FOR_ANALYSTS.md
@@ -190,6 +190,19 @@ import quandl
 data = quandl.get_point_in_time('DATABASE/CODE', interval='asofdate', date='2020-01-01')
 ```
 
+#### Date Format
+
+Dates provided to `get_point_int_time` calls should be a valid ISO8601 formatted string. For example, the following are all valid:
+
+- `2021-03-02`
+- `2021-03-02T13:45:00`
+- `2021-03-02T12:55:00-05:00`
+
+While the following are invalid:
+
+- `2021-03-02 13:45:00` (missing `T` between date and time)
+- `March 2nd, 2021` (not `ISO 8601` compliant)
+
 #### Available options
 
 | Interval | Explanation | Required params | Example |

--- a/test/test_get_point_in_time_data.py
+++ b/test/test_get_point_in_time_data.py
@@ -39,6 +39,12 @@ class GetPointInTimeTest(unittest.TestCase):
         self.assertEqual(mock.call_args, expected)
 
     @patch('quandl.connection.Connection.request')
+    def test_asofdate_call_connection_with_datetimes(self, mock):
+        quandl.get_point_in_time('ZACKS/FC', interval='asofdate', date='2020-01-01T12:55')
+        expected = call('get', 'pit/ZACKS/FC/asofdate/2020-01-01T12:55', params={})
+        self.assertEqual(mock.call_args, expected)
+
+    @patch('quandl.connection.Connection.request')
     def test_asofdate_call_without_date(self, mock):
         quandl.get_point_in_time('ZACKS/FC', interval='asofdate')
         expected = call('get', "pit/ZACKS/FC/asofdate/%s" % date.today(), params={})
@@ -56,6 +62,17 @@ class GetPointInTimeTest(unittest.TestCase):
         self.assertEqual(mock.call_args, expected)
 
     @patch('quandl.connection.Connection.request')
+    def test_from_call_connection_with_datetimes(self, mock):
+        quandl.get_point_in_time(
+            'ZACKS/FC',
+            interval='from',
+            start_date='2020-01-01T12:00',
+            end_date='2020-01-02T14:00'
+        )
+        expected = call('get', 'pit/ZACKS/FC/from/2020-01-01T12:00/to/2020-01-02T14:00', params={})
+        self.assertEqual(mock.call_args, expected)
+
+    @patch('quandl.connection.Connection.request')
     def test_between_call_connection(self, mock):
         quandl.get_point_in_time(
             'ZACKS/FC',
@@ -64,6 +81,17 @@ class GetPointInTimeTest(unittest.TestCase):
             end_date='2020-01-02'
         )
         expected = call('get', 'pit/ZACKS/FC/between/2020-01-01/2020-01-02', params={})
+        self.assertEqual(mock.call_args, expected)
+
+    @patch('quandl.connection.Connection.request')
+    def test_between_call_connection_with_datetimes(self, mock):
+        quandl.get_point_in_time(
+            'ZACKS/FC',
+            interval='between',
+            start_date='2020-01-01T12:00',
+            end_date='2020-01-02T14:00'
+        )
+        expected = call('get', 'pit/ZACKS/FC/between/2020-01-01T12:00/2020-01-02T14:00', params={})
         self.assertEqual(mock.call_args, expected)
 
     @patch('quandl.connection.Connection.request')


### PR DESCRIPTION
- Documentation update to point out that `point_in_time` requests may take a datetime
- Test updates to ensure datetimes objects get sent as expected