### PR TITLE
BRAND-40/switch-quandl-url-to-data-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.6.2 - 2021-11-01
+
+* Switch base URL from www.quandl.com to data.nasdaq.com
+
 ### 3.6.1 - 2021-03-03
 
 * Add documentation/tests for supporting Point In Time datetime values
@@ -25,7 +29,7 @@
 
 * This version is the last `quandl` version to support Python 2 or < 3.5. All future `quandl` package releases will only support Python >= 3.5.
 
-  If you're still using Python 2 or < 3.5, you'll need to stay at this version. 
+  If you're still using Python 2 or < 3.5, you'll need to stay at this version.
 
   If you're using Python >= 3.5, its recommended you perform a `pip install --upgrade quandl` to grab the newest
   version.

--- a/quandl/api_config.py
+++ b/quandl/api_config.py
@@ -4,7 +4,7 @@ import os
 class ApiConfig:
     api_key = None
     api_protocol = 'https://'
-    api_base = '{}www.quandl.com/api/v3'.format(api_protocol)
+    api_base = '{}data.nasdaq.com/api/v3'.format(api_protocol)
     api_version = None  # This is not used but keeping for backwards compatibility
     page_limit = 100
 

--- a/quandl/version.py
+++ b/quandl/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.6.1'
+VERSION = '3.6.2'

--- a/test/helpers/merged_datasets_helper.py
+++ b/test/helpers/merged_datasets_helper.py
@@ -48,23 +48,23 @@ def setupDatasetsTest(unit_test, httpretty):
 
     httpretty.register_uri(httpretty.GET,
                            re.compile(
-                               'https://www.quandl.com/api/v3/datasets/.*/metadata'),
+                               'https://data.nasdaq.com/api/v3/datasets/.*/metadata'),
                            responses=[httpretty.Response(body=json.dumps(dataset))
                                       for dataset in
                                       [unit_test.nse_oil, unit_test.wiki_aapl,
                                        unit_test.wiki_msft]])
     # mock our query param column_index request
     httpretty.register_uri(httpretty.GET,
-                           "https://www.quandl.com/api/v3/datasets/SINGLE/COLUMN/data",
+                           "https://data.nasdaq.com/api/v3/datasets/SINGLE/COLUMN/data",
                            body=json.dumps(unit_test.single_dataset_data))
     httpretty.register_uri(httpretty.GET,
-                           "https://www.quandl.com/api/v3/datasets/WIKI/AAPL/data",
+                           "https://data.nasdaq.com/api/v3/datasets/WIKI/AAPL/data",
                            body=json.dumps(unit_test.dataset_data))
     httpretty.register_uri(httpretty.GET,
                            re.compile(
-                               'https://www.quandl.com/api/v3/datasets/NSE/OIL/data'),
+                               'https://data.nasdaq.com/api/v3/datasets/NSE/OIL/data'),
                            body=json.dumps(unit_test.dataset_data))
     httpretty.register_uri(httpretty.GET,
                            re.compile(
-                               'https://www.quandl.com/api/v3/datasets/WIKI/MSFT/data'),
+                               'https://data.nasdaq.com/api/v3/datasets/WIKI/MSFT/data'),
                            body=json.dumps(unit_test.dataset_data))

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -33,7 +33,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
                          ('QEZx02', 400, QuandlError)]
 
         httpretty.register_uri(getattr(httpretty, request_method),
-                               "https://www.quandl.com/api/v3/databases",
+                               "https://data.nasdaq.com/api/v3/databases",
                                responses=[httpretty.Response(body=json.dumps(
                                    {'quandl_error':
                                     {'code': x[0], 'message': 'something went wrong'}}),
@@ -48,7 +48,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
     def test_parse_error(self, request_method):
         ApiConfig.retry_backoff_factor = 0
         httpretty.register_uri(getattr(httpretty, request_method),
-                               "https://www.quandl.com/api/v3/databases",
+                               "https://data.nasdaq.com/api/v3/databases",
                                body="not json", status=500)
         self.assertRaises(
             QuandlError, lambda: Connection.request(request_method, 'databases'))
@@ -57,7 +57,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
     def test_non_quandl_error(self, request_method):
         ApiConfig.retry_backoff_factor = 0
         httpretty.register_uri(getattr(httpretty, request_method),
-                               "https://www.quandl.com/api/v3/databases",
+                               "https://data.nasdaq.com/api/v3/databases",
                                body=json.dumps(
                                 {'foobar':
                                  {'code': 'blah', 'message': 'something went wrong'}}), status=500)
@@ -72,7 +72,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
         params = {'per_page': 10, 'page': 2}
         headers = {'x-custom-header': 'header value'}
         Connection.request(request_method, 'databases', headers=headers, params=params)
-        expected = call(request_method, 'https://www.quandl.com/api/v3/databases',
+        expected = call(request_method, 'https://data.nasdaq.com/api/v3/databases',
                         headers={'x-custom-header': 'header value',
                                  'x-api-token': 'api_token',
                                  'accept': ('application/json, '

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -56,7 +56,7 @@ class ListDataTest(unittest.TestCase):
         dataset_data = {'dataset_data': DatasetDataFactory.build()}
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datasets*'),
+                                   'https://data.nasdaq.com/api/v3/datasets*'),
                                body=json.dumps(dataset_data))
         cls.expected_raw_data = [{'date': datetime.date(2015, 7, 11), 'column1': 444.3,
                                   'column2': 10, 'column3': 3},
@@ -150,6 +150,6 @@ class ListDataTest(unittest.TestCase):
             'dataset_data': DatasetDataFactory.build(column_names=['blah'])}
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datasets*'),
+                                   'https://data.nasdaq.com/api/v3/datasets*'),
                                body=json.dumps(dataset_data))
         self.assertRaises(InvalidDataError, lambda: Data.all())

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -24,7 +24,7 @@ class GetDatabaseTest(unittest.TestCase):
         database = {'database': DatabaseFactory.build(database_code='NSE')}
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/databases/*'),
+                                   'https://data.nasdaq.com/api/v3/databases/*'),
                                body=json.dumps(database))
         cls.db_instance = Database(Database.get_code_from_meta(
             database['database']), database['database'])
@@ -71,7 +71,7 @@ class ListDatabasesTest(unittest.TestCase):
         databases.update(meta)
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/databases*'),
+                                   'https://data.nasdaq.com/api/v3/databases*'),
                                body=json.dumps(databases))
         cls.expected_databases = databases
 
@@ -113,7 +113,7 @@ class BulkDownloadDatabaseTest(ModifyRetrySettingsTestCase):
         httpretty.enable()
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/databases/*'),
+                                   'https://data.nasdaq.com/api/v3/databases/*'),
                                adding_headers={
                                    'Location': 'https://www.blah.com/download/db.zip'
                                },
@@ -134,7 +134,7 @@ class BulkDownloadDatabaseTest(ModifyRetrySettingsTestCase):
         url = self.database.bulk_download_url(params={'download_type': 'partial'})
         parsed_url = urlparse(url)
         self.assertEqual(parsed_url.scheme, 'https')
-        self.assertEqual(parsed_url.netloc, 'www.quandl.com')
+        self.assertEqual(parsed_url.netloc, 'data.nasdaq.com')
         self.assertEqual(parsed_url.path, '/api/v3/databases/NSE/data')
         self.assertDictEqual(parse_qs(parsed_url.query), {
                              'download_type': ['partial'],
@@ -177,7 +177,7 @@ class BulkDownloadDatabaseTest(ModifyRetrySettingsTestCase):
         httpretty.reset()
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/databases/*'),
+                                   'https://data.nasdaq.com/api/v3/databases/*'),
                                body=json.dumps(
                                    {'quandl_error':
                                     {'code': 'QEMx01', 'message': 'something went wrong'}}),

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -20,7 +20,7 @@ class GetDatasetTest(unittest.TestCase):
             database_code='NSE', dataset_code='OIL')}
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datasets/*'),
+                                   'https://data.nasdaq.com/api/v3/datasets/*'),
                                body=json.dumps(dataset))
         dataset_code = Dataset.get_code_from_meta(dataset['dataset'])
         cls.dataset_instance = Dataset(dataset_code, dataset['dataset'])
@@ -76,7 +76,7 @@ class ListDatasetsTest(unittest.TestCase):
         datasets.update(meta)
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datasets*'),
+                                   'https://data.nasdaq.com/api/v3/datasets*'),
                                body=json.dumps(datasets))
 
     @classmethod

--- a/test/test_datatable.py
+++ b/test/test_datatable.py
@@ -25,7 +25,7 @@ class GetDatatableDatasetTest(ModifyRetrySettingsTestCase):
             vendor_code='ZACKS', datatable_code='FC')}
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables/*'),
+                                   'https://data.nasdaq.com/api/v3/datatables/*'),
                                body=json.dumps(datatable))
         cls.datatable_instance = Datatable(datatable['datatable'])
 
@@ -118,12 +118,12 @@ class ExportDataTableTest(unittest.TestCase):
             vendor_code='AUSBS', datatable_code='D')}
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables/*'),
+                                   'https://data.nasdaq.com/api/v3/datatables/*'),
                                body=json.dumps(datatable))
 
         httpretty.register_uri(httpretty.POST,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables/*'),
+                                   'https://data.nasdaq.com/api/v3/datatables/*'),
                                body=json.dumps(datatable))
         cls.datatable_instance = Datatable(datatable['datatable'])
 
@@ -154,7 +154,7 @@ class ExportDataTableTest(unittest.TestCase):
 
         httpretty.register_uri(getattr(httpretty, request_method),
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables/*'),
+                                   'https://data.nasdaq.com/api/v3/datatables/*'),
                                body=json.dumps({
                                    'datatable_bulk_download': {
                                        'file': {
@@ -190,7 +190,7 @@ class ExportDataTableTest(unittest.TestCase):
 
         httpretty.register_uri(getattr(httpretty, request_method),
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables/*'),
+                                   'https://data.nasdaq.com/api/v3/datatables/*'),
                                responses=error_responses)
 
         self.assertRaises(

--- a/test/test_datatable_data.py
+++ b/test/test_datatable_data.py
@@ -64,12 +64,12 @@ class ListDatatableDataTest(unittest.TestCase):
         datatable_data.update(meta)
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables/*'),
+                                   'https://data.nasdaq.com/api/v3/datatables/*'),
                                body=json.dumps(datatable_data))
 
         httpretty.register_uri(httpretty.POST,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables/*'),
+                                   'https://data.nasdaq.com/api/v3/datatables/*'),
                                body=json.dumps(datatable_data))
         cls.expected_raw_data = []
         cls.expected_list_values = []

--- a/test/test_get_point_in_time_data.py
+++ b/test/test_get_point_in_time_data.py
@@ -16,7 +16,7 @@ class GetPointInTimeTest(unittest.TestCase):
     def setUpClass(cls):
         httpretty.enable()
         httpretty.register_uri(httpretty.GET,
-                               re.compile('https://www.quandl.com/api/v3/pit*'),
+                               re.compile('https://data.nasdaq.com/api/v3/pit*'),
                                body=json.dumps({}))
 
     @classmethod

--- a/test/test_get_table.py
+++ b/test/test_get_table.py
@@ -25,7 +25,7 @@ class GetDataTableTest(unittest.TestCase):
         datatable.update(meta)
         httpretty.register_uri(httpretty.GET,
                                re.compile(
-                                   'https://www.quandl.com/api/v3/datatables*'),
+                                   'https://data.nasdaq.com/api/v3/datatables*'),
                                body=json.dumps(datatable))
         cls.datatable_instance = Datatable(datatable['datatable'])
 

--- a/test/test_point_in_time.py
+++ b/test/test_point_in_time.py
@@ -15,7 +15,7 @@ class GetPointInTimeTest(ModifyRetrySettingsTestCase):
     def setUpClass(cls):
         httpretty.enable()
         httpretty.register_uri(httpretty.GET,
-                               re.compile('https://www.quandl.com/api/v3/pit/*'),
+                               re.compile('https://data.nasdaq.com/api/v3/pit/*'),
                                body=json.dumps({}))
 
     @classmethod

--- a/test/test_retries.py
+++ b/test/test_retries.py
@@ -83,7 +83,7 @@ class TestRetries(ModifyRetrySettingsTestCase):
 
         mock_responses = [self.error_response] + [self.error_response] + [self.success_response]
         httpretty.register_uri(httpretty.GET,
-                               "https://www.quandl.com/api/v3/databases",
+                               "https://data.nasdaq.com/api/v3/databases",
                                responses=mock_responses)
 
         response = Connection.request('get', 'databases')
@@ -96,7 +96,7 @@ class TestRetries(ModifyRetrySettingsTestCase):
         ApiConfig.retry_status_codes = [self.error_response.status]
         mock_responses = [self.error_response] * 3
         httpretty.register_uri(httpretty.GET,
-                               "https://www.quandl.com/api/v3/databases",
+                               "https://data.nasdaq.com/api/v3/databases",
                                responses=mock_responses)
 
         self.assertRaises(InternalServerError, Connection.request, 'get', 'databases')
@@ -106,7 +106,7 @@ class TestRetries(ModifyRetrySettingsTestCase):
         ApiConfig.retry_status_codes = []
         mock_responses = [self.error_response]
         httpretty.register_uri(httpretty.GET,
-                               "https://www.quandl.com/api/v3/databases",
+                               "https://data.nasdaq.com/api/v3/databases",
                                responses=mock_responses)
 
         self.assertRaises(InternalServerError, Connection.request, 'get', 'databases')


### PR DESCRIPTION
Switched URL to match rebrand:

Quandl.com is not Data.nasdaq.com.  As the initial step of the rebrand, we will be querying the new URL.