### PR TITLE
quandl 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.7.0 - 2021-11-10
+
+* Drop Python 3.5 support
+* Update documentation
+* Removes unused test directory
+
 ### 3.6.2 - 2021-11-01
 
 * Switch base URL from www.quandl.com to data.nasdaq.com

--- a/DROP_PYTHON_EOL_SUPPORT.md
+++ b/DROP_PYTHON_EOL_SUPPORT.md
@@ -4,10 +4,10 @@ Python 2 and < 3.6 will be or have already reached their end of life. Therefore,
 will only support Python versions >= 3.6.
 
 * `quandl` versions less than `3.5.0` will only support Python 2 and Python < 3.5.
-* `quandl` versions greater than or equal to `3.6.0` will only support Python >= 3.6
+* `quandl` versions greater than or equal to `3.7.0` will only support Python >= 3.6
 
 If you're using Python 2 or < 3.5, you'll need to stay at `quandl 3.4.9` or lower.
-If you're using 3.5.x, you'll need to stay at `quandl 3.5.x`.
+If you're using Python 3.5.x, you'll need to stay at `quandl 3.5.x`.
 If you're using Python >= 3.6, its recommended to perform a `pip install --upgrade quandl` to grab the
 latest and greatest.
 

--- a/quandl/version.py
+++ b/quandl/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.6.2'
+VERSION = '3.7.0'


### PR DESCRIPTION
Bump client to 3.7.0.

 - Drop support for python 3.5.
 - Update documentation for clarity
 - Removes unused test directory

Signed-off-by: Jamie Couture <jamie.couture@nasdaq.com>